### PR TITLE
iOS Day 8: Binding

### DIFF
--- a/EZ Recipes/EZ Recipes/Views/Recipe/IngredientsList.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/IngredientsList.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct IngredientsList: View {
-    @State var recipe: Recipe
+    @Binding var recipe: Recipe
     
     var body: some View {
         VStack(spacing: 12) {
@@ -32,7 +32,7 @@ struct IngredientsList: View {
 struct IngredientsList_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            IngredientsList(recipe: Constants.Mocks.blueberryYogurt)
+            IngredientsList(recipe: .constant(Constants.Mocks.blueberryYogurt))
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)
         }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/InstructionsList.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/InstructionsList.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InstructionsList: View {
-    @State var recipe: Recipe
+    @Binding var recipe: Recipe
     
     var body: some View {
         VStack(spacing: 8) {
@@ -24,7 +24,7 @@ struct InstructionsList: View {
                 
                 // Steps per instruction
                 ForEach(instruction.steps, id: \.number) { step in
-                    StepCard(step: step)
+                    StepCard(step: .constant(step))
                 }
             }
         }
@@ -34,7 +34,7 @@ struct InstructionsList: View {
 struct InstructionsList_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            InstructionsList(recipe: Constants.Mocks.blueberryYogurt)
+            InstructionsList(recipe: .constant(Constants.Mocks.blueberryYogurt))
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)
         }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/NutritionLabel.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/NutritionLabel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct NutritionLabel: View {
-    @State var recipe: Recipe
+    @Binding var recipe: Recipe
     
     // Nutrients that should be bolded in the nutrition label
     let nutrientHeadings = ["Calories", "Fat", "Carbohydrates", "Protein"]
@@ -49,7 +49,7 @@ struct NutritionLabel: View {
 struct NutritionLabel_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            NutritionLabel(recipe: Constants.Mocks.blueberryYogurt)
+            NutritionLabel(recipe: .constant(Constants.Mocks.blueberryYogurt))
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)
         }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeHeader.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeHeader.swift
@@ -24,7 +24,9 @@ private extension Button {
 }
 
 struct RecipeHeader: View {
-    @State var recipe: Recipe
+    @Binding var recipe: Recipe
+    @Binding var isLoading: Bool
+    var onFindRecipeButtonTapped: () -> Void // callback to pass to the parent View
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
@@ -70,14 +72,19 @@ struct RecipeHeader: View {
                     .tint(.red)
                     
                     Button {
-                        print("Finding another recipe")
+                        onFindRecipeButtonTapped()
                     } label: {
                         Label(Constants.Strings.showRecipeButton, systemImage: "text.book.closed")
                     }
                     .buttonStyle(for: colorScheme)
                     .tint(.yellow)
                     .foregroundColor(colorScheme == .light ? .black : .yellow)
+                    .disabled(isLoading)
                 }
+            }
+            
+            if isLoading {
+                ProgressView()
             }
         }
     }
@@ -86,9 +93,13 @@ struct RecipeHeader: View {
 struct RecipeHeader_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            RecipeHeader(recipe: Constants.Mocks.blueberryYogurt)
+            RecipeHeader(recipe: .constant(Constants.Mocks.blueberryYogurt), isLoading: .constant(false)) {}
                 .previewDevice(PreviewDevice(rawValue: device))
-                .previewDisplayName(device)
+                .previewDisplayName("\(device) (No Loading)")
+            
+            RecipeHeader(recipe: .constant(Constants.Mocks.blueberryYogurt), isLoading: .constant(true)) {}
+                .previewDevice(PreviewDevice(rawValue: device))
+                .previewDisplayName("\(device) (Loading)")
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -16,11 +16,15 @@ struct RecipeView: View {
         ScrollView {
             VStack(spacing: 8) {
                 if let recipe = viewModel.recipe {
-                    RecipeHeader(recipe: recipe)
-                    NutritionLabel(recipe: recipe)
-                    SummaryBox(recipe: recipe)
-                    IngredientsList(recipe: recipe)
-                    InstructionsList(recipe: recipe)
+                    // Since the ViewModel owns the recipe, all child views should bind to the recipe object to respond to updates
+                    RecipeHeader(recipe: .constant(recipe), isLoading: $viewModel.isLoading) {
+                        // When the show another recipe button is tapped, load a new recipe in the same view
+                        viewModel.getRandomRecipe()
+                    }
+                    NutritionLabel(recipe: .constant(recipe))
+                    SummaryBox(recipe: .constant(recipe))
+                    IngredientsList(recipe: .constant(recipe))
+                    InstructionsList(recipe: .constant(recipe))
                     
                     Divider()
                     

--- a/EZ Recipes/EZ Recipes/Views/Recipe/StepCard.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/StepCard.swift
@@ -30,51 +30,55 @@ struct StepCard: View {
             // Align all items to the start
             .frame(maxWidth: .infinity, alignment: .leading)
             
-            Divider()
-            
-            // Ingredients for the step
-            HStack(spacing: 8) {
-                Text(Constants.Strings.ingredients)
-                    .font(.headline.bold())
-                    .padding(.trailing)
+            if !step.ingredients.isEmpty {
+                Divider()
                 
-                // Wrap items if they can't fit in one row
-                LazyVGrid(columns: columns) {
-                    ForEach(step.ingredients, id: \.id) { ingredient in
-                        VStack {
-                            // Scale the height to fit the width of the frame so it doesn't overlap the text
-                            AsyncImage(url: URL(string: "https://spoonacular.com/cdn/ingredients_100x100/\(ingredient.image)"))
-                                .frame(width: 50)
-                                .scaledToFit()
-                            
-                            Text(ingredient.name)
+                // Ingredients for the step
+                HStack(spacing: 8) {
+                    Text(Constants.Strings.ingredients)
+                        .font(.headline.bold())
+                        .padding(.trailing)
+                    
+                    // Wrap items if they can't fit in one row
+                    LazyVGrid(columns: columns) {
+                        ForEach(step.ingredients, id: \.id) { ingredient in
+                            VStack {
+                                // Scale the height to fit the width of the frame so it doesn't overlap the text
+                                AsyncImage(url: URL(string: "https://spoonacular.com/cdn/ingredients_100x100/\(ingredient.image)"))
+                                    .frame(width: 50)
+                                    .scaledToFit()
+                                
+                                Text(ingredient.name)
+                            }
                         }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             
-            Divider()
-            
-            // Equipment for the step
-            HStack(spacing: 8) {
-                Text(Constants.Strings.equipment)
-                    .font(.headline.bold())
-                    .padding(.trailing)
+            if !step.equipment.isEmpty {
+                Divider()
                 
-                LazyVGrid(columns: columns) {
-                    ForEach(step.equipment, id: \.id) { equipment in
-                        VStack {
-                            AsyncImage(url: URL(string: "https://spoonacular.com/cdn/equipment_100x100/\(equipment.image)"))
-                                .frame(width: 50)
-                                .scaledToFit()
-                            
-                            Text(equipment.name)
+                // Equipment for the step
+                HStack(spacing: 8) {
+                    Text(Constants.Strings.equipment)
+                        .font(.headline.bold())
+                        .padding(.trailing)
+                    
+                    LazyVGrid(columns: columns) {
+                        ForEach(step.equipment, id: \.id) { equipment in
+                            VStack {
+                                AsyncImage(url: URL(string: "https://spoonacular.com/cdn/equipment_100x100/\(equipment.image)"))
+                                    .frame(width: 50)
+                                    .scaledToFit()
+                                
+                                Text(equipment.name)
+                            }
                         }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .card()
     }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/StepCard.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/StepCard.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StepCard: View {
-    @State var step: Step
+    @Binding var step: Step
     
     let columns = [
         GridItem(.adaptive(minimum: 100))
@@ -87,7 +87,7 @@ struct StepCard: View {
 struct StepCard_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            StepCard(step: Constants.Mocks.blueberryYogurt.instructions[0].steps[0])
+            StepCard(step: .constant(Constants.Mocks.blueberryYogurt.instructions[0].steps[0]))
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)
         }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/SummaryBox.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/SummaryBox.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SummaryBox: View {
-    @State var recipe: Recipe
+    @Binding var recipe: Recipe
     
     var body: some View {
         VStack(spacing: 8) {
@@ -38,7 +38,7 @@ struct SummaryBox: View {
 struct SummaryBox_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(Device.all, id: \.self) { device in
-            SummaryBox(recipe: Constants.Mocks.blueberryYogurt)
+            SummaryBox(recipe: .constant(Constants.Mocks.blueberryYogurt))
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)
         }


### PR DESCRIPTION
https://user-images.githubusercontent.com/29958092/209456634-8eb5815a-5834-4ac0-933b-a4c6196ad03c.mp4

<img src="https://user-images.githubusercontent.com/29958092/209456635-c346662d-2006-4655-bc68-0ef1503a4211.png" alt="Condensed step cards" width="300">

(Note that in the top video, the recipe image updates as well, but the recording got cut off.)

I was able to implement the "Find Me Another Recipe!" button and remove empty ingredient and equipment lists. (I decided to leave the "I Made This!" button alone since it will be associated with a DB update past the MVP. And temporarily showing a Toast message requires building a custom view or importing a 3rd party library, which aren't ideal.) Removing empty lists was easy, just some if statements. But the first change was a little more involved since I had to make sure the button event propagates to the parent view, ViewModel, and repository and back. The key was to replace the `@State` variables with `@Binding` since the child views don't own the recipe object. That belongs to the ViewModel, and we want to keep it as a single source of truth. I was worried how much this would change the existing code, but wrapping the recipes with `.constant()` fixed most of the problems.

My next PR will take care of all those long-awaited tests. Then we'll switch over to Android.