### PR TITLE
iOS Day 12: Universal Links

### DIFF
--- a/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
+++ b/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
@@ -9,10 +9,15 @@ import SwiftUI
 
 @main
 struct EZ_RecipesApp: App {
+    let viewModel = HomeViewModel(repository: NetworkManager.shared)
+    
     var body: some Scene {
         WindowGroup {
             HomeView()
-                .environmentObject(HomeViewModel(repository: NetworkManager.shared))
+                .environmentObject(viewModel)
+                .onOpenURL { url in
+                    viewModel.handleRecipeLink(url)
+                }
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -38,7 +38,13 @@ struct Constants {
         static let favoriteAlt = "Favorite this recipe"
         static let unFavoriteAlt = "Un-favorite this recipe"
         static let shareAlt = "Share this recipe"
-        static let shareBody = "Check out this low-effort recipe!"
+        static let shareBody: (String) -> String = { recipeName in
+            "Check out this low-effort recipe for \(recipeName)!"
+        }
+        static let shareUrl: (Int) -> URL = { recipeId in
+            URL(string: "https://ez-recipes-web.onrender.com/recipe/\(recipeId)")!
+        }
+        static let unknownRecipe = "unknown recipe"
         
         static let recipeLinkAlt = "Open recipe source"
         // String format specifiers: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html

--- a/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
@@ -64,4 +64,20 @@ class HomeViewModel: ViewModel, ObservableObject {
             updateRecipeProps(from: result)
         }
     }
+    
+    func handleRecipeLink(_ url: URL) {
+        // Check if the universal link is in the format: /recipe/RECIPE_ID
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return }
+        
+        let path = components.path
+        // TODO: replace with Swift's Regex class when targeting iOS 16+
+        let recipeUrlRegex = #"\/recipe\/\d+"# // raw string (no need to escape \)
+        guard path.range(of: recipeUrlRegex, options: .regularExpression) != nil else { return }
+        
+        let recipeIdString = path.components(separatedBy: "/")[2]
+        guard let recipeId = Int(recipeIdString) else { return }
+        
+        // Open RecipeView with the specified recipe ID
+        getRecipe(byId: recipeId)
+    }
 }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -87,7 +87,11 @@ struct RecipeView: View {
                     } else {
                         // Fallback on earlier versions
                         Button {
-                            shareText = ShareText(text: Constants.Strings.shareBody(viewModel.recipe?.name ?? Constants.Strings.unknownRecipe))
+                            shareText = ShareText(
+                                url: Constants.Strings.shareUrl(viewModel.recipe?.id ?? 0),
+                                subject: viewModel.recipe?.name ?? Constants.Strings.unknownRecipe,
+                                message: Constants.Strings.shareBody(viewModel.recipe?.name ?? Constants.Strings.unknownRecipe)
+                            )
                         } label: {
                             Label(Constants.Strings.shareAlt, systemImage: "square.and.arrow.up")
                         }
@@ -96,7 +100,7 @@ struct RecipeView: View {
             }
         }
         .sheet(item: $shareText) { shareText in
-            ActivityView(text: shareText.text)
+            ActivityView(url: shareText.url, subject: shareText.subject, message: shareText.message)
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -78,11 +78,16 @@ struct RecipeView: View {
                     }
                     
                     if #available(iOS 16.0, *) {
-                        ShareLink(Constants.Strings.shareAlt, item: Constants.Strings.shareBody)
+                        ShareLink(
+                            Constants.Strings.shareAlt,
+                            item: Constants.Strings.shareUrl(viewModel.recipe?.id ?? 0),
+                            subject: Text(viewModel.recipe?.name ?? Constants.Strings.unknownRecipe),
+                            message: Text(Constants.Strings.shareBody(viewModel.recipe?.name ?? Constants.Strings.unknownRecipe))
+                        )
                     } else {
                         // Fallback on earlier versions
                         Button {
-                            shareText = ShareText(text: Constants.Strings.shareBody)
+                            shareText = ShareText(text: Constants.Strings.shareBody(viewModel.recipe?.name ?? Constants.Strings.unknownRecipe))
                         } label: {
                             Label(Constants.Strings.shareAlt, systemImage: "square.and.arrow.up")
                         }
@@ -105,12 +110,12 @@ struct RecipeView_Previews: PreviewProvider {
         
         // The preview device and display name don't work when wrapped in a NavigationView (might be a bug)
         return ForEach(Device.all, id: \.self) { device in
-            //NavigationView {
+            NavigationView {
                 RecipeView()
                     .previewDevice(PreviewDevice(rawValue: device))
                     .previewDisplayName(device)
                     .environmentObject(viewModel)
-            //}
+            }
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/UIViews/ActivityView.swift
+++ b/EZ Recipes/EZ Recipes/Views/UIViews/ActivityView.swift
@@ -11,16 +11,46 @@ import SwiftUI
 // Display a share sheet on iOS 15
 // https://stackoverflow.com/a/72035626
 struct ActivityView: UIViewControllerRepresentable {
-    let text: String
+    // A coordinator is needed to implement delegates
+    class Coordinator: NSObject, UIActivityItemSource {
+        var parent: ActivityView
+        
+        init(_ parent: ActivityView) {
+            self.parent = parent
+        }
+        
+        func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+            return "\(parent.message)\n\n\(parent.url.absoluteString)"
+        }
+        
+        func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+            return "\(parent.message)\n\n\(parent.url.absoluteString)"
+        }
+        
+        func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+            return parent.subject
+        }
+    }
+    
+    let url: URL
+    let subject: String
+    let message: String
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<ActivityView>) -> UIActivityViewController {
-        return UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        return UIActivityViewController(activityItems: [self], applicationActivities: nil)
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ActivityView>) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
 }
 
 struct ShareText: Identifiable {
     let id = UUID()
-    let text: String
+    // Matches the parameters in ActivityView
+    let url: URL
+    let subject: String
+    let message: String
 }

--- a/EZ Recipes/EZ RecipesTests/HomeViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/HomeViewModelTests.swift
@@ -92,4 +92,74 @@ final class HomeViewModelTests: XCTestCase {
         viewModel.getRecipe(byId: 1)
         wait(for: [expectation], timeout: 1)
     }
+    
+    @MainActor func testHandleRecipeLinkSuccess() {
+        // Given a universal link from the web app
+        let recipeId = 644783
+        guard let recipeUrl = URL(string: "https://ez-recipes-web.onrender.com/recipe/\(recipeId)") else {
+            XCTFail("The test URL is invalid")
+            return
+        }
+        
+        // When handling the URL
+        viewModel = HomeViewModel(repository: mockRepo)
+        // Then the getRecipe(byId:) method should be called with the recipe ID in the URL
+        let expectation = XCTestExpectation(description: "Fetch a recipe by its ID")
+        
+        viewModel.$recipe.sink { recipe in
+            if recipe?.id == recipeId {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.handleRecipeLink(recipeUrl)
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    @MainActor func testHandleRecipeLinkFailEmptyPath() {
+        // Given a universal link from the web app with an empty path
+        guard let recipeUrl = URL(string: "https://ez-recipes-web.onrender.com") else {
+            XCTFail("The test URL is invalid")
+            return
+        }
+        
+        // When handling the URL
+        viewModel = HomeViewModel(repository: mockRepo)
+        // Then the getRecipe(byId:) method shouldn't be called
+        let expectation = XCTestExpectation(description: "Fetch a recipe by its ID")
+        
+        viewModel.$recipe.sink { recipe in
+            if recipe == nil {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.handleRecipeLink(recipeUrl)
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    @MainActor func testHandleRecipeLinkFailInvalidRecipePath() {
+        // Given a universal link from the web app with an invalid recipe path
+        guard let recipeUrl = URL(string: "https://ez-recipes-web.onrender.com/recipe/-1") else {
+            XCTFail("The test URL is invalid")
+            return
+        }
+        
+        // When handling the URL
+        viewModel = HomeViewModel(repository: mockRepo)
+        // Then the getRecipe(byId:) method shouldn't be called
+        let expectation = XCTestExpectation(description: "Fetch a recipe by its ID")
+        
+        viewModel.$recipe.sink { recipe in
+            if recipe == nil {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.handleRecipeLink(recipeUrl)
+        wait(for: [expectation], timeout: 1)
+    }
 }


### PR DESCRIPTION
I added most of the functionality I could when trying to implement universal links into my iOS app. When a user opens the web app in Safari and they have the iOS app installed, they will be redirected to open the recipe screen for that specific ID. The only thing I couldn't do is add the Associated Domains entitlement due to limitations in my Apple Developer account. I talk about it more in #7.

I also modified the share button so it shares a URL to the EZ Recipes web app. This would trigger the above behavior if the user clicks on the link with the iOS app installed.

Related PRs:
- Web: _to be added_
- Android: _to be added_