### PR TITLE
Feature/search 2

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		F122BBC42B899C2000302FCA /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */; };
 		F122BBC62B8A7EE600302FCA /* SubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC52B8A7EE600302FCA /* SubmitButton.swift */; };
+		F122BBC82B8AB6EF00302FCA /* SearchSecondaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC72B8AB6EF00302FCA /* SearchSecondaryView.swift */; };
 		F123A846293D85CE00C8E127 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A845293D85CE00C8E127 /* DoubleExtension.swift */; };
 		F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */; };
 		F12C1C2B2904951600C3302B /* EZ_RecipesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12C1C2A2904951600C3302B /* EZ_RecipesApp.swift */; };
@@ -23,7 +24,7 @@
 		F12C1C662904D16700C3302B /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = F12C1C652904D16700C3302B /* Alamofire */; };
 		F13037B3293291AF003E562C /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = F13037B5293291AF003E562C /* Localizable.stringsdict */; };
 		F13037B92932B6A7003E562C /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13037B82932B6A7003E562C /* ActivityView.swift */; };
-		F1320CDA297C923B00070DC8 /* SecondaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1320CD9297C923B00070DC8 /* SecondaryView.swift */; };
+		F1320CDA297C923B00070DC8 /* HomeSecondaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1320CD9297C923B00070DC8 /* HomeSecondaryView.swift */; };
 		F1320CDC297C9ADE00070DC8 /* RecipeTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1320CDB297C9ADE00070DC8 /* RecipeTitle.swift */; };
 		F1437C0229564511005408E5 /* IngredientsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1437C0129564511005408E5 /* IngredientsList.swift */; };
 		F1437C042956681C005408E5 /* StepCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1437C032956681C005408E5 /* StepCard.swift */; };
@@ -92,6 +93,7 @@
 		F10BFB1529A1DEDA00636841 /* screenshots */ = {isa = PBXFileReference; lastKnownFileType = folder; name = screenshots; path = ../screenshots; sourceTree = "<group>"; };
 		F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		F122BBC52B8A7EE600302FCA /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
+		F122BBC72B8AB6EF00302FCA /* SearchSecondaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSecondaryView.swift; sourceTree = "<group>"; };
 		F123A845293D85CE00C8E127 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensionTests.swift; sourceTree = "<group>"; };
 		F12C1C272904951600C3302B /* EZ Recipes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EZ Recipes.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,7 +114,7 @@
 		F12C1C622904CED500C3302B /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		F13037B4293291AF003E562C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		F13037B82932B6A7003E562C /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
-		F1320CD9297C923B00070DC8 /* SecondaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryView.swift; sourceTree = "<group>"; };
+		F1320CD9297C923B00070DC8 /* HomeSecondaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSecondaryView.swift; sourceTree = "<group>"; };
 		F1320CDB297C9ADE00070DC8 /* RecipeTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeTitle.swift; sourceTree = "<group>"; };
 		F1437C0129564511005408E5 /* IngredientsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientsList.swift; sourceTree = "<group>"; };
 		F1437C032956681C005408E5 /* StepCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepCard.swift; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 			isa = PBXGroup;
 			children = (
 				F15CB9E42B75A4EC0031F725 /* SearchView.swift */,
+				F122BBC72B8AB6EF00302FCA /* SearchSecondaryView.swift */,
 				F15CB9EF2B770F520031F725 /* FilterForm.swift */,
 				F17A80A12B783C1500E811C8 /* FormError.swift */,
 				F122BBC52B8A7EE600302FCA /* SubmitButton.swift */,
@@ -365,7 +368,7 @@
 			isa = PBXGroup;
 			children = (
 				F12C1C2C2904951600C3302B /* HomeView.swift */,
-				F1320CD9297C923B00070DC8 /* SecondaryView.swift */,
+				F1320CD9297C923B00070DC8 /* HomeSecondaryView.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 				F12C1C2D2904951600C3302B /* HomeView.swift in Sources */,
 				F1C7DA0B2B6F3AC100D6E343 /* RecipeFilter.swift in Sources */,
 				F1F38EC1290F5088000FF99C /* Instruction.swift in Sources */,
+				F122BBC82B8AB6EF00302FCA /* SearchSecondaryView.swift in Sources */,
 				F1F38EC3290F509B000FF99C /* Step.swift in Sources */,
 				F15CB9E82B75A6470031F725 /* ContentView.swift in Sources */,
 				F1437C0229564511005408E5 /* IngredientsList.swift in Sources */,
@@ -584,7 +588,7 @@
 				F12C1C2B2904951600C3302B /* EZ_RecipesApp.swift in Sources */,
 				F1EAC7F6292185D70046B268 /* ViewModel.swift in Sources */,
 				F1EAC7F129217E250046B268 /* RecipeView.swift in Sources */,
-				F1320CDA297C923B00070DC8 /* SecondaryView.swift in Sources */,
+				F1320CDA297C923B00070DC8 /* HomeSecondaryView.swift in Sources */,
 				F13037B92932B6A7003E562C /* ActivityView.swift in Sources */,
 				F1F38EB7290F215C000FF99C /* HomeViewModel.swift in Sources */,
 				F15CB9F42B770F7F0031F725 /* RecipeCard.swift in Sources */,

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F122BBC42B899C2000302FCA /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */; };
 		F123A846293D85CE00C8E127 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A845293D85CE00C8E127 /* DoubleExtension.swift */; };
 		F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */; };
 		F12C1C2B2904951600C3302B /* EZ_RecipesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12C1C2A2904951600C3302B /* EZ_RecipesApp.swift */; };
@@ -88,6 +89,7 @@
 		F10BFB1129A1821800636841 /* 1.0.0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = 1.0.0.txt; sourceTree = "<group>"; };
 		F10BFB1329A197D600636841 /* Pluginfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Pluginfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F10BFB1529A1DEDA00636841 /* screenshots */ = {isa = PBXFileReference; lastKnownFileType = folder; name = screenshots; path = ../screenshots; sourceTree = "<group>"; };
+		F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		F123A845293D85CE00C8E127 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensionTests.swift; sourceTree = "<group>"; };
 		F12C1C272904951600C3302B /* EZ Recipes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EZ Recipes.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -252,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				F1F38EBA290F3751000FF99C /* HomeViewModelTests.swift */,
+				F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */,
 				F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */,
 				F17A80AA2B7966B100E811C8 /* CaseIterableExtensionTests.swift */,
 				F1BD63A42B81605800B704AD /* RecipeFilterEncoderTests.swift */,
@@ -610,6 +613,7 @@
 				F17A80AB2B7966B100E811C8 /* CaseIterableExtensionTests.swift in Sources */,
 				F1BD63A52B81605800B704AD /* RecipeFilterEncoderTests.swift in Sources */,
 				F1F38EBB290F3751000FF99C /* HomeViewModelTests.swift in Sources */,
+				F122BBC42B899C2000302FCA /* SearchViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		F122BBC42B899C2000302FCA /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */; };
+		F122BBC62B8A7EE600302FCA /* SubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122BBC52B8A7EE600302FCA /* SubmitButton.swift */; };
 		F123A846293D85CE00C8E127 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A845293D85CE00C8E127 /* DoubleExtension.swift */; };
 		F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */; };
 		F12C1C2B2904951600C3302B /* EZ_RecipesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12C1C2A2904951600C3302B /* EZ_RecipesApp.swift */; };
@@ -90,6 +91,7 @@
 		F10BFB1329A197D600636841 /* Pluginfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Pluginfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F10BFB1529A1DEDA00636841 /* screenshots */ = {isa = PBXFileReference; lastKnownFileType = folder; name = screenshots; path = ../screenshots; sourceTree = "<group>"; };
 		F122BBC32B899C2000302FCA /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
+		F122BBC52B8A7EE600302FCA /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
 		F123A845293D85CE00C8E127 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensionTests.swift; sourceTree = "<group>"; };
 		F12C1C272904951600C3302B /* EZ Recipes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EZ Recipes.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -352,6 +354,7 @@
 				F15CB9E42B75A4EC0031F725 /* SearchView.swift */,
 				F15CB9EF2B770F520031F725 /* FilterForm.swift */,
 				F17A80A12B783C1500E811C8 /* FormError.swift */,
+				F122BBC52B8A7EE600302FCA /* SubmitButton.swift */,
 				F15CB9F12B770F610031F725 /* SearchResults.swift */,
 				F15CB9F32B770F7F0031F725 /* RecipeCard.swift */,
 			);
@@ -602,6 +605,7 @@
 				F1E0FD48293D73B20007255F /* RecipeFooter.swift in Sources */,
 				F1C7DA112B703CB700D6E343 /* Pill.swift in Sources */,
 				F1F38EBD290F5053000FF99C /* Nutrient.swift in Sources */,
+				F122BBC62B8A7EE600302FCA /* SubmitButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
+++ b/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
@@ -9,14 +9,13 @@ import SwiftUI
 
 @main
 struct EZ_RecipesApp: App {
-    let viewModel = HomeViewModel(repository: NetworkManager.shared)
+    let homeViewModel = HomeViewModel(repository: NetworkManager.shared)
     
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(viewModel)
                 .onOpenURL { url in
-                    viewModel.handleRecipeLink(url)
+                    homeViewModel.handleRecipeLink(url)
                 }
         }
     }

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -9,7 +9,29 @@ import Foundation
 import SwiftUI
 
 struct Constants {
+    // Common strings
     static let appName = "EZ Recipes"
+    static let errorTitle = "Error"
+    static let unknownError = "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-ios/issues"
+    static let okButton = "OK"
+    static let loadingMessages = [
+        "Prepping the ingredients... 🍱",
+        "Preheating the oven... ⏲️",
+        "Going grocery shopping... 🛒",
+        "Drying the meat... 🥩",
+        "Chopping onions... 😭",
+        "Dicing fruit... 🍎",
+        "Steaming veggies... 🥗",
+        "Applying condiments... 🧂",
+        "Spicing things up... 🌶️",
+        "Melting the butter... 🧈",
+        "Mashing the potatoes... 🥔",
+        "Fluffing some rice... 🍚",
+        "Mixing things up... 🥘",
+        "Shaking things up... 🍲"
+    ]
+    
+    // APIs
     static let serverBaseUrl = "https://ez-recipes-server.onrender.com"
     static let recipesPath = "/api/recipes"
     static let termsPath = "/api/terms"
@@ -43,25 +65,6 @@ struct Constants {
     struct HomeView {
         static let homeTitle = "Home"
         static let findRecipeButton = "Find Me a Recipe!"
-        static let errorTitle = "Error"
-        static let unknownError = "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-ios/issues"
-        static let okButton = "OK"
-        static let loadingMessages = [
-            "Prepping the ingredients... 🍱",
-            "Preheating the oven... ⏲️",
-            "Going grocery shopping... 🛒",
-            "Drying the meat... 🥩",
-            "Chopping onions... 😭",
-            "Dicing fruit... 🍎",
-            "Steaming veggies... 🥗",
-            "Applying condiments... 🧂",
-            "Spicing things up... 🌶️",
-            "Melting the butter... 🧈",
-            "Mashing the potatoes... 🥔",
-            "Fluffing some rice... 🍚",
-            "Mixing things up... 🥘",
-            "Shaking things up... 🍲"
-        ]
         
         // Secondary view
         static let selectRecipe = "Select a recipe from the navigation menu."

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -160,6 +160,7 @@ struct Constants {
         static let typeLabel = "Meal Type"
         static let cultureLabel = "Cuisine"
         static let submitButton = "Apply"
+        static let noResults = "No recipes found"
         
         // Results
         static let resultsTitle = "Results"

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -137,6 +137,9 @@ struct Constants {
     struct SearchView {
         static let searchTitle = "Search"
         
+        // Secondary view
+        static let searchRecipes = "Search for recipes by applying filters from the navigation menu."
+        
         // Filter form
         static let querySection = "Query"
         static let queryPlaceholder = "food"

--- a/EZ Recipes/EZ Recipes/Helpers/NetworkManagerMock.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/NetworkManagerMock.swift
@@ -9,9 +9,10 @@
 struct NetworkManagerMock: RecipeRepository {
     static let shared = NetworkManagerMock()
     var isSuccess = true // controls whether the mock API calls succeed or fail
+    var noResults = false
     
     func getRecipes(withFilter filter: RecipeFilter) async -> Result<[Recipe], RecipeError> {
-        return isSuccess ? .success([Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken]) : .failure(Constants.Mocks.recipeError)
+        return isSuccess ? .success(noResults ? [] : [Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken]) : .failure(Constants.Mocks.recipeError)
     }
     
     func getRandomRecipe() async -> Result<Recipe, RecipeError> {

--- a/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
@@ -13,12 +13,14 @@ class HomeViewModel: ViewModel, ObservableObject {
     // Don't allow the View to make changes to the ViewModel, except for bindings
     @Published private(set) var task: Task<(), Never>? = nil
     @Published var isLoading = false
+    
     @Published var isRecipeLoaded = false
     @Published private(set) var recipe: Recipe? {
         didSet {
             isRecipeLoaded = recipe != nil
         }
     }
+    
     @Published var recipeFailedToLoad = false
     @Published var recipeError: RecipeError? {
         didSet {

--- a/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
@@ -37,6 +37,10 @@ class HomeViewModel: ViewModel, ObservableObject {
         self.repository = repository
     }
     
+    func setRecipe(_ recipe: Recipe) {
+        self.recipe = recipe
+    }
+    
     private func updateRecipeProps(from result: Result<Recipe, RecipeError>) {
         // Set the recipe and recipeError properties based on whether the result was successful
         switch result {

--- a/EZ Recipes/EZ Recipes/ViewModels/SearchViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/SearchViewModel.swift
@@ -14,9 +14,11 @@ class SearchViewModel: ViewModel, ObservableObject {
     @Published var recipeFilter = RecipeFilter()
     
     @Published var isRecipeLoaded = false
+    @Published var noRecipesFound = false
     @Published private(set) var recipes: [Recipe] = [] {
         didSet {
             isRecipeLoaded = !recipes.isEmpty
+            noRecipesFound = recipes.isEmpty
         }
     }
     
@@ -35,6 +37,7 @@ class SearchViewModel: ViewModel, ObservableObject {
     
     func searchRecipes() {
         task = Task {
+            noRecipesFound = false
             isLoading = true
             let result = await repository.getRecipes(withFilter: recipeFilter)
             isLoading = false

--- a/EZ Recipes/EZ Recipes/ViewModels/SearchViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/SearchViewModel.swift
@@ -10,10 +10,22 @@ import Foundation
 @MainActor
 class SearchViewModel: ViewModel, ObservableObject {
     @Published private(set) var task: Task<(), Never>? = nil
-    @Published private(set) var isLoading = false
+    @Published var isLoading = false
     @Published var recipeFilter = RecipeFilter()
-    @Published private(set) var recipes: [Recipe] = []
-    @Published private(set) var recipeError: RecipeError? = nil
+    
+    @Published var isRecipeLoaded = false
+    @Published private(set) var recipes: [Recipe] = [] {
+        didSet {
+            isRecipeLoaded = !recipes.isEmpty
+        }
+    }
+    
+    @Published var recipeFailedToLoad = false
+    @Published private(set) var recipeError: RecipeError? {
+        didSet {
+            recipeFailedToLoad = recipeError != nil && task?.isCancelled == false
+        }
+    }
     
     private var repository: RecipeRepository
     

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
-            HomeView()
+            HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
                 .tabItem {
                     Label(Constants.Tabs.home, systemImage: "house")
                 }
@@ -23,10 +23,7 @@ struct ContentView: View {
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static let viewModel = HomeViewModel(repository: NetworkManagerMock.shared)
-    
     static var previews: some View {
         ContentView()
-            .environmentObject(viewModel)
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeSecondaryView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeSecondaryView.swift
@@ -1,5 +1,5 @@
 //
-//  SecondaryView.swift
+//  HomeSecondaryView.swift
 //  EZ Recipes
 //
 //  Created by Abhishek Chaudhuri on 1/21/23.
@@ -7,14 +7,14 @@
 
 import SwiftUI
 
-struct SecondaryView: View {
+struct HomeSecondaryView: View {
     var body: some View {
         Text(Constants.HomeView.selectRecipe)
     }
 }
 
-struct SecondaryView_Previews: PreviewProvider {
+struct HomeSecondaryView_Previews: PreviewProvider {
     static var previews: some View {
-        SecondaryView()
+        HomeSecondaryView()
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -33,11 +33,11 @@ struct HomeView: View {
                     // Prevent users from spamming the button
                     .disabled(viewModel.isLoading)
                     // Show an alert if the request failed
-                    .alert(Constants.HomeView.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
-                        Button(Constants.HomeView.okButton, role: .cancel) {}
+                    .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
+                        Button(Constants.okButton, role: .cancel) {}
                     } message: {
                         // recipeError shouldn't be nil if recipeFailedToLoad is true
-                        Text(viewModel.recipeError?.error ?? Constants.HomeView.unknownError)
+                        Text(viewModel.recipeError?.error ?? Constants.unknownError)
                     }
                 }
                 
@@ -54,7 +54,7 @@ struct HomeView: View {
                         }
                     }
                     .onReceive(timer) { _ in
-                        loadingMessage = Constants.HomeView.loadingMessages.randomElement() ?? " "
+                        loadingMessage = Constants.loadingMessages.randomElement() ?? " "
                     }
             }
             .navigationTitle(Constants.HomeView.homeTitle)

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     // Subscribe to changes in the ObservableObject and automatically update the UI
-    @EnvironmentObject private var viewModel: HomeViewModel
+    @StateObject var viewModel: HomeViewModel
     
     // Don't show any messages initially if the recipe loads quickly
     // " " will allocate space for the loading message so the UI doesn't dynamically shift
@@ -21,7 +21,7 @@ struct HomeView: View {
         NavigationView {
             VStack {
                 // Show the recipe view once the recipe loads in the ViewModel
-                NavigationLink(destination: RecipeView(), isActive: $viewModel.isRecipeLoaded) {
+                NavigationLink(destination: RecipeView(viewModel: viewModel), isActive: $viewModel.isRecipeLoaded) {
                     Button {
                         viewModel.getRandomRecipe()
                     } label: {
@@ -85,15 +85,12 @@ struct HomeView_Previews: PreviewProvider {
         repoFail.isSuccess = false
         
         return ForEach([1], id: \.self) {_ in
-            HomeView()
+            HomeView(viewModel: viewModelWithoutLoading)
                 .previewDisplayName("No Loading")
-                .environmentObject(viewModelWithoutLoading)
-            HomeView()
+            HomeView(viewModel: viewModelWithLoading)
                 .previewDisplayName("Loading")
-                .environmentObject(viewModelWithLoading)
-            HomeView()
+            HomeView(viewModel: viewModelWithAlert)
                 .previewDisplayName("Alert")
-                .environmentObject(viewModelWithAlert)
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -13,8 +13,9 @@ struct HomeView: View {
     
     // Don't show any messages initially if the recipe loads quickly
     // " " will allocate space for the loading message so the UI doesn't dynamically shift
+    private let defaultLoadingMessage = " "
     @State private var loadingMessage = " "
-    let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+    private let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
     
     var body: some View {
         NavigationView {
@@ -50,11 +51,11 @@ struct HomeView: View {
                     // TODO: change to the 0 or 2-parameter variant if this deprecated modifier is removed
                     .onChange(of: viewModel.isLoading) { isLoading in
                         if isLoading {
-                            loadingMessage = " "
+                            loadingMessage = defaultLoadingMessage
                         }
                     }
                     .onReceive(timer) { _ in
-                        loadingMessage = Constants.loadingMessages.randomElement() ?? " "
+                        loadingMessage = Constants.loadingMessages.randomElement() ?? defaultLoadingMessage
                     }
             }
             .navigationTitle(Constants.HomeView.homeTitle)

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -61,7 +61,7 @@ struct HomeView: View {
             .navigationTitle(Constants.HomeView.homeTitle)
             
             // Show a message in the secondary view that tells the user to select a recipe (only visible on wide screens)
-            SecondaryView()
+            HomeSecondaryView()
         }
         .navigationViewStyle(.automatic) // TODO: when iOS 16 is the minimum deployment target, migrate to NavigationStack/NavigationSplitView: https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types
         .onDisappear {

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeHeader.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeHeader.swift
@@ -33,8 +33,14 @@ struct RecipeHeader: View {
         VStack(spacing: 16) {
             // Recipe image and caption
             VStack {
-                AsyncImage(url: URL(string: recipe.image))
-                    .frame(width: 312, height: 231)
+                AsyncImage(url: URL(string: recipe.image)) { image in
+                    // Shrink the image if too big while maintaining its aspect ratio
+                    image.resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 312, maxHeight: 231)
+                } placeholder: {
+                    ProgressView()
+                }
                 
                 if let credit = recipe.credit {
                     // Add a clickable link to the image source

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeView: View {
-    @EnvironmentObject private var viewModel: HomeViewModel
+    var viewModel: HomeViewModel
     @State var isFavorite = false
     @State var shareText: ShareText?
     
@@ -113,8 +113,7 @@ struct RecipeView_Previews: PreviewProvider {
         viewModel.getRandomRecipe()
         
         return NavigationView {
-            RecipeView()
-                .environmentObject(viewModel)
+            RecipeView(viewModel: viewModel)
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct RecipeView: View {
-    var viewModel: HomeViewModel
+    // Mark as @ObservedObject when the ViewModel is mutable
+    @ObservedObject var viewModel: HomeViewModel
     @State var isFavorite = false
     @State var shareText: ShareText?
     

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -35,6 +35,9 @@ struct FilterForm: View {
             }
             Section(Constants.SearchView.filterSection) {
                 HStack {
+                    // Extend the divider all the way to the left (it goes up to the first "text" element)
+                    // https://stackoverflow.com/a/77823150
+                    Text("")
                     Spacer()
                     TextField(String(MIN_CALS), value: $viewModel.recipeFilter.minCals, format: .number)
                         .frame(width: 75)
@@ -101,9 +104,8 @@ struct FilterForm: View {
                 }
                 .mpPickerStyle(.navigationLink)
             }
-            NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
-                SubmitButton(viewModel: viewModel, isDisabled: caloriesExceedMax || caloriesInvalidRange || viewModel.isLoading)
-            }
+            SubmitButton(viewModel: viewModel)
+                .disabled(caloriesExceedMax || caloriesInvalidRange || viewModel.isLoading)
         }
         .toolbar {
             // Add buttons above the keyboard for ease of navigation

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -134,32 +134,26 @@ struct FilterForm_Previews: PreviewProvider {
     static let emptyRecipeFilter = SearchViewModel(repository: mockRepo)
     static var recipeFilterWithMaxError = SearchViewModel(repository: mockRepo)
     static var recipeFilterWithRangeError = SearchViewModel(repository: mockRepo)
-    
-    // Allow the recipe filter to be mutated in the preview
-    struct BindingTestHolder: View {
-        @State var viewModel: SearchViewModel
-        
-        var body: some View {
-            NavigationView {
-                FilterForm(viewModel: viewModel)
-            }
-        }
-    }
+    static var viewModelLoading = SearchViewModel(repository: mockRepo)
     
     static var previews: some View {
         recipeFilterWithMaxError.recipeFilter.maxCals = 2001
         recipeFilterWithRangeError.recipeFilter.minCals = 200
         recipeFilterWithRangeError.recipeFilter.maxCals = 100
+        viewModelLoading.isLoading = true
         
         return ForEach([1], id: \.self) {_ in
-            BindingTestHolder(viewModel: emptyRecipeFilter)
+            FilterForm(viewModel: emptyRecipeFilter)
                 .previewDisplayName("Empty")
             
-            BindingTestHolder(viewModel: recipeFilterWithMaxError)
+            FilterForm(viewModel: recipeFilterWithMaxError)
                 .previewDisplayName("Max Error")
             
-            BindingTestHolder(viewModel: recipeFilterWithRangeError)
+            FilterForm(viewModel: recipeFilterWithRangeError)
                 .previewDisplayName("Range Error")
+            
+            FilterForm(viewModel: viewModelLoading)
+                .previewDisplayName("Loading")
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
@@ -30,11 +30,15 @@ struct RecipeCard: View {
                     Label(isFavorite ? Constants.RecipeView.unFavoriteAlt : Constants.RecipeView.favoriteAlt, systemImage: isFavorite ? "heart.fill" : "heart")
                 }
             }
+            .padding(.bottom, 8)
             
             HStack {
+                Spacer()
                 Text(Constants.RecipeView.recipeTime(recipe.time))
+                Spacer()
                 if let calories = getCalories() {
-                    Text("\(calories.amount) \(calories.unit)")
+                    Text("\(calories.amount.round()) \(calories.unit)")
+                    Spacer()
                 }
             }
         }

--- a/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
@@ -19,6 +19,7 @@ struct RecipeCard: View {
         VStack {
             AsyncImage(url: URL(string: recipe.image))
                 .frame(width: 312, height: 231)
+                .clipped() // prevent large images from overlapping the card
             Divider()
             
             HStack {

--- a/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/RecipeCard.swift
@@ -17,9 +17,13 @@ struct RecipeCard: View {
     
     var body: some View {
         VStack {
-            AsyncImage(url: URL(string: recipe.image))
-                .frame(width: 312, height: 231)
-                .clipped() // prevent large images from overlapping the card
+            AsyncImage(url: URL(string: recipe.image)) { image in
+                image.resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 312, maxHeight: 231)
+            } placeholder: {
+                ProgressView()
+            }
             Divider()
             
             HStack {

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchResults.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchResults.swift
@@ -10,23 +10,35 @@ import SwiftUI
 struct SearchResults: View {
     var recipes: [Recipe]
     
+    let columns = [
+        GridItem(.adaptive(minimum: 350), alignment: .top)
+    ]
+    
     var body: some View {
-        VStack {
-            Text(Constants.SearchView.resultsTitle)
-                .font(.title)
-            ForEach(recipes, id: \.id) { recipe in
-                RecipeCard(recipe: recipe)
+        ScrollView {
+            LazyVGrid(columns: columns, alignment: .center, spacing: 8) {
+                ForEach(recipes, id: \.id) { recipe in
+                    NavigationLink(destination: EmptyView()) {
+                        RecipeCard(recipe: recipe)
+                    }
+                    // Don't make all the text the accent color
+                    .buttonStyle(.plain)
+                }
             }
         }
+        .navigationTitle(Constants.SearchView.resultsTitle)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
 struct SearchResults_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResults(recipes: [
-            Constants.Mocks.blueberryYogurt,
-            Constants.Mocks.chocolateCupcake,
-            Constants.Mocks.thaiBasilChicken
-        ])
+        NavigationView {
+            SearchResults(recipes: [
+                Constants.Mocks.blueberryYogurt,
+                Constants.Mocks.chocolateCupcake,
+                Constants.Mocks.thaiBasilChicken
+            ])
+        }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchResults.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchResults.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SearchResults: View {
     var recipes: [Recipe]
+    let homeViewModel = HomeViewModel(repository: NetworkManager.shared)
     
     let columns = [
         GridItem(.adaptive(minimum: 350), alignment: .top)
@@ -18,11 +19,15 @@ struct SearchResults: View {
         ScrollView {
             LazyVGrid(columns: columns, alignment: .center, spacing: 8) {
                 ForEach(recipes, id: \.id) { recipe in
-                    NavigationLink(destination: EmptyView()) {
+                    NavigationLink(destination: RecipeView(viewModel: homeViewModel)) {
                         RecipeCard(recipe: recipe)
                     }
                     // Don't make all the text the accent color
                     .buttonStyle(.plain)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        // Populate the recipe directly without making an API call
+                        homeViewModel.setRecipe(recipe)
+                    })
                 }
             }
         }

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchSecondaryView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchSecondaryView.swift
@@ -1,0 +1,20 @@
+//
+//  SearchSecondaryView.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 2/24/24.
+//
+
+import SwiftUI
+
+struct SearchSecondaryView: View {
+    var body: some View {
+        Text(Constants.SearchView.searchRecipes)
+    }
+}
+
+struct SearchSecondaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchSecondaryView()
+    }
+}

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
@@ -14,6 +14,8 @@ struct SearchView: View {
         NavigationView {
             FilterForm(viewModel: viewModel)
                 .navigationTitle(Constants.SearchView.searchTitle)
+            
+            SearchSecondaryView()
         }
         .navigationViewStyle(.automatic)
         .onDisappear {

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
@@ -10,14 +10,36 @@ import SwiftUI
 struct SearchView: View {
     @StateObject var viewModel: SearchViewModel
     
+    @State private var loadingMessage = " "
+    let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+    
     var body: some View {
         NavigationView {
             VStack {
-                FilterForm(recipeFilter: $viewModel.recipeFilter) {
-                    viewModel.searchRecipes()
+                NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
+                    FilterForm(recipeFilter: $viewModel.recipeFilter) {
+                        viewModel.searchRecipes()
+                    }
+                    .disabled(viewModel.isLoading)
+                    .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
+                        Button(Constants.okButton, role: .cancel) {}
+                    } message: {
+                        Text(viewModel.recipeError?.error ?? Constants.unknownError)
+                    }
                 }
                 
-                SearchResults(recipes: viewModel.recipes)
+                ProgressView()
+                    .opacity(viewModel.isLoading ? 1 : 0)
+                Text(loadingMessage)
+                    .opacity(viewModel.isLoading ? 1 : 0)
+                    .onChange(of: viewModel.isLoading) { isLoading in
+                        if isLoading {
+                            loadingMessage = " "
+                        }
+                    }
+                    .onReceive(timer) { _ in
+                        loadingMessage = Constants.loadingMessages.randomElement() ?? " "
+                    }
             }
             .navigationTitle(Constants.SearchView.searchTitle)
         }
@@ -29,10 +51,24 @@ struct SearchView: View {
 }
 
 struct SearchView_Previews: PreviewProvider {
-    static let mockNetworkManager = NetworkManagerMock.shared
-    static let viewModel = SearchViewModel(repository: mockNetworkManager)
+    static let repoSuccess = NetworkManagerMock.shared
+    static var repoFail = NetworkManagerMock.shared
+    
+    static let viewModelWithoutLoading = SearchViewModel(repository: repoSuccess)
+    static let viewModelWithLoading = SearchViewModel(repository: repoSuccess)
+    static let viewModelWithAlert = SearchViewModel(repository: repoFail)
     
     static var previews: some View {
-        SearchView(viewModel: viewModel)
+        viewModelWithLoading.isLoading = true
+        repoFail.isSuccess = false
+        
+        return ForEach([1], id: \.self) { _ in
+            SearchView(viewModel: viewModelWithoutLoading)
+                .previewDisplayName("No Loading")
+            SearchView(viewModel: viewModelWithLoading)
+                .previewDisplayName("Loading")
+            SearchView(viewModel: viewModelWithAlert)
+                .previewDisplayName("Alert")
+        }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SearchView.swift
@@ -10,38 +10,10 @@ import SwiftUI
 struct SearchView: View {
     @StateObject var viewModel: SearchViewModel
     
-    @State private var loadingMessage = " "
-    let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
-    
     var body: some View {
         NavigationView {
-            VStack {
-                NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
-                    FilterForm(recipeFilter: $viewModel.recipeFilter) {
-                        viewModel.searchRecipes()
-                    }
-                    .disabled(viewModel.isLoading)
-                    .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
-                        Button(Constants.okButton, role: .cancel) {}
-                    } message: {
-                        Text(viewModel.recipeError?.error ?? Constants.unknownError)
-                    }
-                }
-                
-                ProgressView()
-                    .opacity(viewModel.isLoading ? 1 : 0)
-                Text(loadingMessage)
-                    .opacity(viewModel.isLoading ? 1 : 0)
-                    .onChange(of: viewModel.isLoading) { isLoading in
-                        if isLoading {
-                            loadingMessage = " "
-                        }
-                    }
-                    .onReceive(timer) { _ in
-                        loadingMessage = Constants.loadingMessages.randomElement() ?? " "
-                    }
-            }
-            .navigationTitle(Constants.SearchView.searchTitle)
+            FilterForm(viewModel: viewModel)
+                .navigationTitle(Constants.SearchView.searchTitle)
         }
         .navigationViewStyle(.automatic)
         .onDisappear {
@@ -51,24 +23,10 @@ struct SearchView: View {
 }
 
 struct SearchView_Previews: PreviewProvider {
-    static let repoSuccess = NetworkManagerMock.shared
-    static var repoFail = NetworkManagerMock.shared
-    
-    static let viewModelWithoutLoading = SearchViewModel(repository: repoSuccess)
-    static let viewModelWithLoading = SearchViewModel(repository: repoSuccess)
-    static let viewModelWithAlert = SearchViewModel(repository: repoFail)
+    static let mockRepo = NetworkManagerMock.shared
+    static let viewModel = SearchViewModel(repository: mockRepo)
     
     static var previews: some View {
-        viewModelWithLoading.isLoading = true
-        repoFail.isSuccess = false
-        
-        return ForEach([1], id: \.self) { _ in
-            SearchView(viewModel: viewModelWithoutLoading)
-                .previewDisplayName("No Loading")
-            SearchView(viewModel: viewModelWithLoading)
-                .previewDisplayName("Loading")
-            SearchView(viewModel: viewModelWithAlert)
-                .previewDisplayName("Alert")
-        }
+        SearchView(viewModel: viewModel)
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SubmitButton: View {
     @ObservedObject var viewModel: SearchViewModel
-    var isDisabled: Bool
     
     // Don't take up additional space when hidden
     private let defaultLoadingMessage = ""
@@ -22,7 +21,7 @@ struct SubmitButton: View {
                 Button(Constants.SearchView.submitButton) {
                     viewModel.searchRecipes()
                 }
-                .disabled(isDisabled)
+                .disabled(viewModel.isLoading)
                 .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
                     Button(Constants.okButton, role: .cancel) {}
                 } message: {
@@ -44,6 +43,11 @@ struct SubmitButton: View {
                         loadingMessage = Constants.loadingMessages.randomElement() ?? defaultLoadingMessage
                     }
             }
+            
+            NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
+                EmptyView()
+            }
+            .hidden()
         }
     }
 }
@@ -58,10 +62,9 @@ struct SubmitButton_Previews: PreviewProvider {
     
     struct BindingTestHolder: View {
         @State var viewModel: SearchViewModel
-        @State var isDisabled: Bool
         
         var body: some View {
-            SubmitButton(viewModel: viewModel, isDisabled: isDisabled)
+            SubmitButton(viewModel: viewModel)
                 .border(.primary)
         }
     }
@@ -71,11 +74,11 @@ struct SubmitButton_Previews: PreviewProvider {
         repoFail.isSuccess = false
         
         return ForEach([1], id: \.self) { _ in
-            BindingTestHolder(viewModel: viewModelWithoutLoading, isDisabled: false)
+            BindingTestHolder(viewModel: viewModelWithoutLoading)
                 .previewDisplayName("No Loading")
-            BindingTestHolder(viewModel: viewModelWithLoading, isDisabled: true)
+            BindingTestHolder(viewModel: viewModelWithLoading)
                 .previewDisplayName("Loading")
-            BindingTestHolder(viewModel: viewModelWithAlert, isDisabled: false)
+            BindingTestHolder(viewModel: viewModelWithAlert)
                 .previewDisplayName("Alert")
         }
     }

--- a/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
@@ -31,9 +31,17 @@ struct SubmitButton: View {
                 
                 ProgressView()
                     .opacity(viewModel.isLoading ? 1 : 0)
+                
+                // Prevent navigation unless the recipes are loaded
+                NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
+                    EmptyView()
+                }
+                .hidden()
             }
             if viewModel.isLoading {
                 Text(loadingMessage)
+                    .multilineTextAlignment(.leading)
+                    .padding(.top, 1)
                     .onChange(of: viewModel.isLoading) { isLoading in
                         if isLoading {
                             loadingMessage = defaultLoadingMessage
@@ -43,11 +51,6 @@ struct SubmitButton: View {
                         loadingMessage = Constants.loadingMessages.randomElement() ?? defaultLoadingMessage
                     }
             }
-            
-            NavigationLink(destination: SearchResults(recipes: viewModel.recipes), isActive: $viewModel.isRecipeLoaded) {
-                EmptyView()
-            }
-            .hidden()
         }
     }
 }
@@ -60,25 +63,16 @@ struct SubmitButton_Previews: PreviewProvider {
     static let viewModelWithLoading = SearchViewModel(repository: repoSuccess)
     static let viewModelWithAlert = SearchViewModel(repository: repoFail)
     
-    struct BindingTestHolder: View {
-        @State var viewModel: SearchViewModel
-        
-        var body: some View {
-            SubmitButton(viewModel: viewModel)
-                .border(.primary)
-        }
-    }
-    
     static var previews: some View {
         viewModelWithLoading.isLoading = true
         repoFail.isSuccess = false
         
         return ForEach([1], id: \.self) { _ in
-            BindingTestHolder(viewModel: viewModelWithoutLoading)
+            SubmitButton(viewModel: viewModelWithoutLoading)
                 .previewDisplayName("No Loading")
-            BindingTestHolder(viewModel: viewModelWithLoading)
+            SubmitButton(viewModel: viewModelWithLoading)
                 .previewDisplayName("Loading")
-            BindingTestHolder(viewModel: viewModelWithAlert)
+            SubmitButton(viewModel: viewModelWithAlert)
                 .previewDisplayName("Alert")
         }
     }

--- a/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
@@ -1,0 +1,82 @@
+//
+//  SubmitButton.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 2/24/24.
+//
+
+import SwiftUI
+
+struct SubmitButton: View {
+    @ObservedObject var viewModel: SearchViewModel
+    var isDisabled: Bool
+    
+    // Don't take up additional space when hidden
+    private let defaultLoadingMessage = ""
+    @State private var loadingMessage = ""
+    private let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Button(Constants.SearchView.submitButton) {
+                    viewModel.searchRecipes()
+                }
+                .disabled(isDisabled)
+                .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
+                    Button(Constants.okButton, role: .cancel) {}
+                } message: {
+                    Text(viewModel.recipeError?.error ?? Constants.unknownError)
+                }
+                .padding(.trailing)
+                
+                ProgressView()
+                    .opacity(viewModel.isLoading ? 1 : 0)
+            }
+            if viewModel.isLoading {
+                Text(loadingMessage)
+                    .onChange(of: viewModel.isLoading) { isLoading in
+                        if isLoading {
+                            loadingMessage = defaultLoadingMessage
+                        }
+                    }
+                    .onReceive(timer) { _ in
+                        loadingMessage = Constants.loadingMessages.randomElement() ?? defaultLoadingMessage
+                    }
+            }
+        }
+    }
+}
+
+struct SubmitButton_Previews: PreviewProvider {
+    static let repoSuccess = NetworkManagerMock.shared
+    static var repoFail = NetworkManagerMock.shared
+    
+    static let viewModelWithoutLoading = SearchViewModel(repository: repoSuccess)
+    static let viewModelWithLoading = SearchViewModel(repository: repoSuccess)
+    static let viewModelWithAlert = SearchViewModel(repository: repoFail)
+    
+    struct BindingTestHolder: View {
+        @State var viewModel: SearchViewModel
+        @State var isDisabled: Bool
+        
+        var body: some View {
+            SubmitButton(viewModel: viewModel, isDisabled: isDisabled)
+                .border(.primary)
+        }
+    }
+    
+    static var previews: some View {
+        viewModelWithLoading.isLoading = true
+        repoFail.isSuccess = false
+        
+        return ForEach([1], id: \.self) { _ in
+            BindingTestHolder(viewModel: viewModelWithoutLoading, isDisabled: false)
+                .previewDisplayName("No Loading")
+            BindingTestHolder(viewModel: viewModelWithLoading, isDisabled: true)
+                .previewDisplayName("Loading")
+            BindingTestHolder(viewModel: viewModelWithAlert, isDisabled: false)
+                .previewDisplayName("Alert")
+        }
+    }
+}

--- a/EZ Recipes/EZ RecipesTests/HomeViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/HomeViewModelTests.swift
@@ -14,6 +14,18 @@ final class HomeViewModelTests: XCTestCase {
     var viewModel: HomeViewModel!
     private var cancellable = Set<AnyCancellable>()
     
+    @MainActor func testSetRecipe() {
+        // Given a recipe
+        let recipe = Constants.Mocks.thaiBasilChicken
+        
+        // When setRecipe() is called
+        viewModel = HomeViewModel(repository: mockRepo)
+        viewModel.setRecipe(recipe)
+        
+        // Then the recipe property should match the given recipe
+        XCTAssertEqual(viewModel.recipe, recipe)
+    }
+    
     @MainActor func testGetRandomRecipeSuccess() {
         // Given a ViewModel
         viewModel = HomeViewModel(repository: mockRepo)

--- a/EZ Recipes/EZ RecipesTests/SearchViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/SearchViewModelTests.swift
@@ -33,6 +33,26 @@ final class SearchViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
+    @MainActor func testSearchRecipesNoResults() {
+        // Given a ViewModel
+        mockRepo.noResults = true
+        viewModel = SearchViewModel(repository: mockRepo)
+        
+        // When searchRecipes() is called with an empty response
+        // Then the recipes property should be empty
+        let expectation = XCTestExpectation(description: "Search recipes")
+        
+        viewModel.$recipes.sink { recipes in
+            if recipes.isEmpty {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.searchRecipes()
+        wait(for: [expectation], timeout: 1)
+    }
+    
     @MainActor func testSearchRecipesFail() {
         // Given a ViewModel where API requests fail
         mockRepo.isSuccess = false

--- a/EZ Recipes/EZ RecipesTests/SearchViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/SearchViewModelTests.swift
@@ -1,0 +1,55 @@
+//
+//  SearchViewModelTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 2/23/24.
+//
+
+import XCTest
+import Combine
+@testable import EZ_Recipes
+
+final class SearchViewModelTests: XCTestCase {
+    var mockRepo = NetworkManagerMock.shared
+    var viewModel: SearchViewModel!
+    private var cancellable = Set<AnyCancellable>()
+    
+    @MainActor func testSearchRecipesSuccess() {
+        // Given a ViewModel
+        viewModel = SearchViewModel(repository: mockRepo)
+        
+        // When searchRecipes() is called
+        // Then the recipes property should match the mock response
+        let expectation = XCTestExpectation(description: "Search recipes")
+        
+        viewModel.$recipes.sink { recipes in
+            if recipes == [Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken] {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.searchRecipes()
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    @MainActor func testSearchRecipesFail() {
+        // Given a ViewModel where API requests fail
+        mockRepo.isSuccess = false
+        viewModel = SearchViewModel(repository: mockRepo)
+        
+        // When searchRecipes() is called
+        // Then the recipeError property should match the mock recipe error
+        let expectation = XCTestExpectation(description: "Search recipes")
+        
+        viewModel.$recipeError.sink { recipeError in
+            if recipeError == Constants.Mocks.recipeError {
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellable)
+        
+        viewModel.searchRecipes()
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -212,7 +212,7 @@ class EZ_RecipesUITests: XCTestCase {
         veganSwitch.tap()
         
         let glutenFreeText = collectionViewsQuery.staticTexts["Gluten-Free"]
-        XCTAssert(vegetarianText.exists, "Error line \(#line): The gluten-free switch couldn't be found")
+        XCTAssert(glutenFreeText.exists, "Error line \(#line): The gluten-free switch couldn't be found")
         let glutenFreeSwitch = collectionViewsQuery.switches["Gluten-Free"].switches.firstMatch
         glutenFreeSwitch.tap()
         
@@ -229,7 +229,7 @@ class EZ_RecipesUITests: XCTestCase {
         cheapSwitch.tap()
         
         let sustainableText = collectionViewsQuery.staticTexts["Sustainable"]
-        XCTAssert(vegetarianText.exists, "Error line \(#line): The sustainable switch couldn't be found")
+        XCTAssert(sustainableText.exists, "Error line \(#line): The sustainable switch couldn't be found")
         let sustainableSwitch = collectionViewsQuery.switches["Sustainable"].switches.firstMatch
         sustainableSwitch.tap()
         sustainableSwitch.tap()

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -186,19 +186,27 @@ class EZ_RecipesUITests: XCTestCase {
         let calorieRangeError = collectionViewsQuery.staticTexts["Error: Max calories cannot exceed min calories"]
         XCTAssert(calorieRangeError.exists, "Error line \(#line): The calorie range error isn't shown")
         let submitButton = collectionViewsQuery.buttons["Apply"]
+        collectionViewsQuery.element.swipeUp()
         XCTAssertFalse(submitButton.isEnabled, "Error line \(#line): The submit button should be disabled")
+        collectionViewsQuery.element.swipeDown()
         
         maxCaloriesTextField.tap()
         maxCaloriesTextField.typeText("00")
+        doneButton.tap()
         let maxCaloriesError = collectionViewsQuery.staticTexts["Error: Calories must be ≤ 2000"]
         XCTAssert(maxCaloriesError.exists, "Error line \(#line): The max calorie error isn't shown")
+        collectionViewsQuery.element.swipeUp()
         XCTAssertFalse(submitButton.isEnabled, "Error line \(#line): The submit button should be disabled")
+        collectionViewsQuery.element.swipeDown()
         
+        maxCaloriesTextField.tap()
         maxCaloriesTextField.typeText(XCUIKeyboardKey.delete.rawValue)
         doneButton.tap()
         XCTAssertFalse(calorieRangeError.exists, "Error line \(#line): The calorie range error is still visible")
         XCTAssertFalse(maxCaloriesError.exists, "Error line \(#line): The max calorie error is still visible")
+        collectionViewsQuery.element.swipeUp()
         XCTAssert(submitButton.isEnabled, "Error line \(#line): The submit button should be enabled")
+        collectionViewsQuery.element.swipeDown()
         
         let vegetarianText = collectionViewsQuery.staticTexts["Vegetarian"]
         XCTAssert(vegetarianText.exists, "Error line \(#line): The vegetarian switch couldn't be found")
@@ -266,6 +274,7 @@ class EZ_RecipesUITests: XCTestCase {
             dinnerButton.tap()
         }
         dinnerButton.tap()
+        collectionViewsQuery.element.swipeUp()
         let lunchButton = collectionViewsQuery.buttons["lunch"]
         lunchButton.tap()
         let mainCourseButton = collectionViewsQuery.buttons["main course"]
@@ -284,8 +293,10 @@ class EZ_RecipesUITests: XCTestCase {
         let cuisineButton = collectionViewsQuery.buttons["Cuisine"]
         cuisineButton.tap()
         let italianButton = collectionViewsQuery.buttons["Italian"]
-        if !italianButton.isHittable {
-            italianButton.tap()
+        if !italianButton.exists {
+            collectionViewsQuery.element.swipeUp() // for small screens
+        } else if !italianButton.isHittable && cuisineButton.exists {
+            italianButton.tap() // for large screens
         }
         italianButton.tap()
         

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -138,6 +138,9 @@ class EZ_RecipesUITests: XCTestCase {
     func testSearchRecipes() throws {
         // Go to the Search tab
         app.tabBars["Tab Bar"].buttons["Search"].tap()
+        var shotNum = 1
+        snapshot("search-view-\(shotNum)")
+        shotNum += 1
         
         // If the sidebar button exists, check that the search recipes text is shown and tapping the sidebar button opens the filter form
         let sidebarButton = app.navigationBars.buttons["ToggleSidebar"]
@@ -147,6 +150,8 @@ class EZ_RecipesUITests: XCTestCase {
             XCTAssert(searchRecipes.exists, "Error line \(#line): The secondary view text isn't showing")
             
             sidebarButton.tap()
+            snapshot("search-view-\(shotNum)")
+            shotNum += 1
         }
         
         // Interact with all the filter options
@@ -228,31 +233,53 @@ class EZ_RecipesUITests: XCTestCase {
         let sustainableSwitch = collectionViewsQuery.switches["Sustainable"].switches.firstMatch
         sustainableSwitch.tap()
         sustainableSwitch.tap()
-//        let app = XCUIApplication()
-//        let collectionViewsQuery = app.collectionViews
-//        let mealTypeButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["Meal Type"]/*[[".cells.buttons[\"Meal Type\"]",".buttons[\"Meal Type\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        mealTypeButton.tap()
-//        mealTypeButton.tap()
-//        
-//        let antipastiButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["antipasti"]/*[[".cells.buttons[\"antipasti\"]",".buttons[\"antipasti\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        antipastiButton.tap()
-//        
-//        let antipastoButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["antipasto"]/*[[".cells.buttons[\"antipasto\"]",".buttons[\"antipasto\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        antipastoButton.tap()
-//        
-//        let appetizerButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["appetizer"]/*[[".cells.buttons[\"appetizer\"]",".buttons[\"appetizer\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        appetizerButton.tap()
-//        
-//        let beverageButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["beverage"]/*[[".cells.buttons[\"beverage\"]",".buttons[\"beverage\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        beverageButton.tap()
-//        
-//        let breadButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["bread"]/*[[".cells.buttons[\"bread\"]",".buttons[\"bread\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-//        breadButton.tap()
-//        beverageButton.tap()
-//        appetizerButton.tap()
-//        antipastoButton.tap()
-//        antipastiButton.tap()
-//        breadButton.tap()
         
+        let spiceLevelText = collectionViewsQuery.staticTexts["Spice Level"]
+        XCTAssert(spiceLevelText.exists, "Error line \(#line): The spice level picker couldn't be found")
+        let spiceLevelButton = collectionViewsQuery.buttons["Spice Level"]
+        spiceLevelButton.tap()
+        let noneButton = collectionViewsQuery.buttons["none"]
+        noneButton.tap()
+        let mildButton = collectionViewsQuery.buttons["mild"]
+        mildButton.tap()
+        let spicyButton = collectionViewsQuery.buttons["spicy"]
+        spicyButton.tap()
+        spicyButton.tap()
+        let backSearchButton = app.navigationBars.buttons["Search"]
+        backSearchButton.tap()
+        
+        let mealTypeText = collectionViewsQuery.staticTexts["Meal Type"]
+        XCTAssert(mealTypeText.exists, "Error line \(#line): The meal type picker couldn't be found")
+        let mealTypeButton = collectionViewsQuery.buttons["Meal Type"]
+        mealTypeButton.tap()
+        let dinnerButton = collectionViewsQuery.buttons["dinner"]
+        dinnerButton.tap()
+        let lunchButton = collectionViewsQuery.buttons["lunch"]
+        lunchButton.tap()
+        let mainCourseButton = collectionViewsQuery.buttons["main course"]
+        mainCourseButton.tap()
+        let mainDishButton = collectionViewsQuery.buttons["main dish"]
+        mainDishButton.tap()
+        backSearchButton.tap()
+        
+        let cuisineText = collectionViewsQuery.staticTexts["Cuisine"]
+        XCTAssert(cuisineText.exists, "Error line \(#line): The cuisine picker couldn't be found")
+        let cuisineButton = collectionViewsQuery.buttons["Cuisine"]
+        cuisineButton.tap()
+        let italianButton = collectionViewsQuery.buttons["Italian"]
+        italianButton.tap()
+        backSearchButton.tap()
+        let cuisines = collectionViewsQuery.staticTexts["Italian"]
+        XCTAssert(cuisines.exists, "Error line \(#line): The cuisines selected aren't shown")
+        snapshot("search-view-\(shotNum)")
+        shotNum += 1
+        
+        // Submit the form and wait for results
+        submitButton.tap()
+        XCTAssertFalse(submitButton.isEnabled, "Error line \(#line): The submit button should be disabled")
+        let resultsNavigationBar = app.navigationBars["Results"]
+        XCTAssert(resultsNavigationBar.waitForExistence(timeout: 30), "Error line \(#line): The recipe results didn't load (the API request timed out after 30 seconds)")
+        snapshot("search-view-\(shotNum)")
+        shotNum += 1
     }
 }

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -239,6 +239,10 @@ class EZ_RecipesUITests: XCTestCase {
         let spiceLevelButton = collectionViewsQuery.buttons["Spice Level"]
         spiceLevelButton.tap()
         let noneButton = collectionViewsQuery.buttons["none"]
+        // Tap twice on iPads to dismiss the sidebar
+        if !noneButton.isHittable {
+            noneButton.tap()
+        }
         noneButton.tap()
         let mildButton = collectionViewsQuery.buttons["mild"]
         mildButton.tap()
@@ -246,13 +250,21 @@ class EZ_RecipesUITests: XCTestCase {
         spicyButton.tap()
         spicyButton.tap()
         let backSearchButton = app.navigationBars.buttons["Search"]
-        backSearchButton.tap()
+        
+        if backSearchButton.exists {
+            backSearchButton.tap()
+        } else if sidebarButton.exists {
+            sidebarButton.tap()
+        }
         
         let mealTypeText = collectionViewsQuery.staticTexts["Meal Type"]
         XCTAssert(mealTypeText.exists, "Error line \(#line): The meal type picker couldn't be found")
         let mealTypeButton = collectionViewsQuery.buttons["Meal Type"]
         mealTypeButton.tap()
         let dinnerButton = collectionViewsQuery.buttons["dinner"]
+        if !dinnerButton.isHittable {
+            dinnerButton.tap()
+        }
         dinnerButton.tap()
         let lunchButton = collectionViewsQuery.buttons["lunch"]
         lunchButton.tap()
@@ -260,15 +272,29 @@ class EZ_RecipesUITests: XCTestCase {
         mainCourseButton.tap()
         let mainDishButton = collectionViewsQuery.buttons["main dish"]
         mainDishButton.tap()
-        backSearchButton.tap()
+        
+        if backSearchButton.exists {
+            backSearchButton.tap()
+        } else if sidebarButton.exists {
+            sidebarButton.tap()
+        }
         
         let cuisineText = collectionViewsQuery.staticTexts["Cuisine"]
         XCTAssert(cuisineText.exists, "Error line \(#line): The cuisine picker couldn't be found")
         let cuisineButton = collectionViewsQuery.buttons["Cuisine"]
         cuisineButton.tap()
         let italianButton = collectionViewsQuery.buttons["Italian"]
+        if !italianButton.isHittable {
+            italianButton.tap()
+        }
         italianButton.tap()
-        backSearchButton.tap()
+        
+        if backSearchButton.exists {
+            backSearchButton.tap()
+        } else if sidebarButton.exists {
+            sidebarButton.tap()
+        }
+        
         let cuisines = collectionViewsQuery.staticTexts["Italian"]
         XCTAssert(cuisines.exists, "Error line \(#line): The cuisines selected aren't shown")
         snapshot("search-view-\(shotNum)")

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -33,7 +33,7 @@ class EZ_RecipesUITests: XCTestCase {
         snapshot("home-view-\(shotNum)")
         shotNum += 1
         
-        // If the sidebar button exists, check that the select recipe text is showing and tapping the sidebar button opens the home view
+        // If the sidebar button exists, check that the select recipe text is shown and tapping the sidebar button opens the home view
         let sidebarButton = app.navigationBars.buttons["ToggleSidebar"]
         
         if sidebarButton.exists {
@@ -133,5 +133,126 @@ class EZ_RecipesUITests: XCTestCase {
         // Check that tapping the show another recipe button disables the button (the ProgressView check doesn't work in the pipeline)
         showAnotherRecipeButton.tap()
         XCTAssertFalse(showAnotherRecipeButton.isEnabled, "Error line \(#line): The show button should be disabled")
+    }
+    
+    func testSearchRecipes() throws {
+        // Go to the Search tab
+        app.tabBars["Tab Bar"].buttons["Search"].tap()
+        
+        // If the sidebar button exists, check that the search recipes text is shown and tapping the sidebar button opens the filter form
+        let sidebarButton = app.navigationBars.buttons["ToggleSidebar"]
+        
+        if sidebarButton.exists {
+            let searchRecipes = app.staticTexts["Search for recipes by applying filters from the navigation menu."]
+            XCTAssert(searchRecipes.exists, "Error line \(#line): The secondary view text isn't showing")
+            
+            sidebarButton.tap()
+        }
+        
+        // Interact with all the filter options
+        let collectionViewsQuery = app.collectionViews
+        let foodTextField = collectionViewsQuery.textFields["food"]
+        foodTextField.tap()
+        foodTextField.typeText("pasta")
+        
+        // Navigate using the toolbar above the keyboard
+        let toolbar = app.toolbars["Toolbar"]
+        let previousButton = toolbar.buttons["Previous"]
+        let nextButton = toolbar.buttons["Next"]
+        let doneButton = toolbar.buttons["Done"]
+        XCTAssertFalse(previousButton.isEnabled, "Error line \(#line): The previous button isn't disabled")
+        XCTAssert(nextButton.isEnabled, "Error line \(#line): The next button isn't enabled")
+        
+        let minCaloriesTextField = collectionViewsQuery.textFields["0"]
+        minCaloriesTextField.tap()
+        let calories = collectionViewsQuery.staticTexts["kcal"]
+        XCTAssert(calories.exists, "Error line \(#line): No calories label was found")
+        minCaloriesTextField.typeText("500")
+        XCTAssert(previousButton.isEnabled, "Error line \(#line): The previous button isn't enabled")
+        XCTAssert(nextButton.isEnabled, "Error line \(#line): The next button isn't enabled")
+        
+        let maxCaloriesTextField = collectionViewsQuery.textFields["2000"]
+        maxCaloriesTextField.tap()
+        maxCaloriesTextField.typeText("80")
+        XCTAssert(previousButton.isEnabled, "Error line \(#line): The previous button isn't enabled")
+        XCTAssertFalse(nextButton.isEnabled, "Error line \(#line): The next button isn't disabled")
+        doneButton.tap()
+        
+        let calorieRangeError = collectionViewsQuery.staticTexts["Error: Max calories cannot exceed min calories"]
+        XCTAssert(calorieRangeError.exists, "Error line \(#line): The calorie range error isn't shown")
+        let submitButton = collectionViewsQuery.buttons["Apply"]
+        XCTAssertFalse(submitButton.isEnabled, "Error line \(#line): The submit button should be disabled")
+        
+        maxCaloriesTextField.tap()
+        maxCaloriesTextField.typeText("00")
+        let maxCaloriesError = collectionViewsQuery.staticTexts["Error: Calories must be ≤ 2000"]
+        XCTAssert(maxCaloriesError.exists, "Error line \(#line): The max calorie error isn't shown")
+        XCTAssertFalse(submitButton.isEnabled, "Error line \(#line): The submit button should be disabled")
+        
+        maxCaloriesTextField.typeText(XCUIKeyboardKey.delete.rawValue)
+        doneButton.tap()
+        XCTAssertFalse(calorieRangeError.exists, "Error line \(#line): The calorie range error is still visible")
+        XCTAssertFalse(maxCaloriesError.exists, "Error line \(#line): The max calorie error is still visible")
+        XCTAssert(submitButton.isEnabled, "Error line \(#line): The submit button should be enabled")
+        
+        let vegetarianText = collectionViewsQuery.staticTexts["Vegetarian"]
+        XCTAssert(vegetarianText.exists, "Error line \(#line): The vegetarian switch couldn't be found")
+        let vegetarianSwitch = collectionViewsQuery.switches["Vegetarian"].switches.firstMatch
+        vegetarianSwitch.tap()
+        
+        let veganText = collectionViewsQuery.staticTexts["Vegan"]
+        XCTAssert(veganText.exists, "Error line \(#line): The vegan switch couldn't be found")
+        let veganSwitch = collectionViewsQuery.switches["Vegan"].switches.firstMatch
+        veganSwitch.tap()
+        veganSwitch.tap()
+        
+        let glutenFreeText = collectionViewsQuery.staticTexts["Gluten-Free"]
+        XCTAssert(vegetarianText.exists, "Error line \(#line): The gluten-free switch couldn't be found")
+        let glutenFreeSwitch = collectionViewsQuery.switches["Gluten-Free"].switches.firstMatch
+        glutenFreeSwitch.tap()
+        
+        let healthyText = collectionViewsQuery.staticTexts["Healthy"]
+        XCTAssert(healthyText.exists, "Error line \(#line): The healthy switch couldn't be found")
+        let healthySwitch = collectionViewsQuery.switches["Healthy"].switches.firstMatch
+        healthySwitch.tap()
+        healthySwitch.tap()
+        
+        let cheapText = collectionViewsQuery.staticTexts["Cheap"]
+        XCTAssert(cheapText.exists, "Error line \(#line): The cheap switch couldn't be found")
+        let cheapSwitch = collectionViewsQuery.switches["Cheap"].switches.firstMatch
+        cheapSwitch.tap()
+        cheapSwitch.tap()
+        
+        let sustainableText = collectionViewsQuery.staticTexts["Sustainable"]
+        XCTAssert(vegetarianText.exists, "Error line \(#line): The sustainable switch couldn't be found")
+        let sustainableSwitch = collectionViewsQuery.switches["Sustainable"].switches.firstMatch
+        sustainableSwitch.tap()
+        sustainableSwitch.tap()
+//        let app = XCUIApplication()
+//        let collectionViewsQuery = app.collectionViews
+//        let mealTypeButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["Meal Type"]/*[[".cells.buttons[\"Meal Type\"]",".buttons[\"Meal Type\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        mealTypeButton.tap()
+//        mealTypeButton.tap()
+//        
+//        let antipastiButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["antipasti"]/*[[".cells.buttons[\"antipasti\"]",".buttons[\"antipasti\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        antipastiButton.tap()
+//        
+//        let antipastoButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["antipasto"]/*[[".cells.buttons[\"antipasto\"]",".buttons[\"antipasto\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        antipastoButton.tap()
+//        
+//        let appetizerButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["appetizer"]/*[[".cells.buttons[\"appetizer\"]",".buttons[\"appetizer\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        appetizerButton.tap()
+//        
+//        let beverageButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["beverage"]/*[[".cells.buttons[\"beverage\"]",".buttons[\"beverage\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        beverageButton.tap()
+//        
+//        let breadButton = collectionViewsQuery/*@START_MENU_TOKEN@*/.buttons["bread"]/*[[".cells.buttons[\"bread\"]",".buttons[\"bread\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+//        breadButton.tap()
+//        beverageButton.tap()
+//        appetizerButton.tap()
+//        antipastoButton.tap()
+//        antipastiButton.tap()
+//        breadButton.tap()
+        
     }
 }


### PR DESCRIPTION
https://github.com/Abhiek187/ez-recipes-ios/assets/29958092/f0bb143a-54aa-4128-9a59-ba90ed0695ee

This is a continuation of #37 and includes the following changes:

- A similar pattern to the HomeView where we show a ProgressView and then navigate to the search results (with the same loading messages)
  - This involved juggling some stuff between `SearchView`, `FilterForm`, and `SubmitButton`, but I was able to find a way
- Responsive recipe cards on the results screen
- Transitioning from the search results to the RecipeView, while passing data between ViewModels
  - In doing so, I removed the need for a global `@EnvironmentObject`
- Fixed how async images load so they stay within the specified dimensions
- A secondary view for iPads
- Unit tests for the SearchViewModel
- SearchView UI tests

Compared to the last PR, this part was easier to implement. There might be some other features I can implement, but for the most part, the iOS app is good to go.