### PR TITLE
Update docs & bump version to 2.0.0

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F1E0FD43293D24CF0007255F /* RecipeHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeHeader.swift; sourceTree = "<group>"; };
 		F1E0FD47293D73B20007255F /* RecipeFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeFooter.swift; sourceTree = "<group>"; };
 		F1E0FD49293D753C0007255F /* NutritionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionLabel.swift; sourceTree = "<group>"; };
+		F1E48B0E2B8BCA4500A40169 /* 2.0.0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = 2.0.0.txt; sourceTree = "<group>"; };
 		F1EAC7EA29216F350046B268 /* NetworkManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerMock.swift; sourceTree = "<group>"; };
 		F1EAC7F029217E250046B268 /* RecipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeView.swift; sourceTree = "<group>"; };
 		F1EAC7F3292185B90046B268 /* RecipeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeRepository.swift; sourceTree = "<group>"; };
@@ -198,6 +199,7 @@
 			isa = PBXGroup;
 			children = (
 				F10BFB1129A1821800636841 /* 1.0.0.txt */,
+				F1E48B0E2B8BCA4500A40169 /* 2.0.0.txt */,
 			);
 			path = changelogs;
 			sourceTree = "<group>";
@@ -800,7 +802,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-Recipes";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -829,7 +831,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-Recipes";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/EZ Recipes/EZ Recipes/Views/Recipe/SummaryBox.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/SummaryBox.swift
@@ -21,7 +21,7 @@ struct SummaryBox: View {
                     .accessibilityHidden(true) // make the image decorative
             }
             
-            //HTMLText(recipe.summary)
+            //HTMLText(summary)
             // Remove all HTML tags from the string
             Text(summary.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil))
             

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 
+@MainActor
 class EZ_RecipesUITests: XCTestCase {
     var app: XCUIApplication!
 

--- a/EZ Recipes/fastlane/Snapfile
+++ b/EZ Recipes/fastlane/Snapfile
@@ -13,13 +13,13 @@
 # ])
 
 # 10 screenshots per locale, each with 4 required screen sizes, with corresponding portrait and landscape sizes:
-# - 6.5-inch iPhone screenshots
+# - 6.7-inch iPhone screenshots
 # - 5.5-inch iPhone screenshots
 # - 12.9-inch iPad screenshots for 2nd generation
 # - 12.9-inch iPad screenshots for 3rd generation
 # Supported devices: https://github.com/fastlane/fastlane/blob/master/snapshot/lib/snapshot/reports_generator.rb
 #                    https://github.com/fastlane/fastlane/blob/master/frameit/lib/frameit/device_types.rb
-devices(["iPhone 8", "iPhone 14 Pro Max", "iPad Pro (12.9-inch) (6th generation)", "iPad Pro (9.7-inch)"])
+devices(["iPhone SE (3rd generation)", "iPhone 14 Pro Max", "iPad Pro (12.9-inch) (6th generation)", "iPad mini (6th generation)"])
 
 # languages([
 #   "en-US",

--- a/EZ Recipes/fastlane/SnapshotHelper.swift
+++ b/EZ Recipes/fastlane/SnapshotHelper.swift
@@ -15,13 +15,12 @@
 import Foundation
 import XCTest
 
-var deviceLanguage = ""
-var locale = ""
-
+@MainActor
 func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
     Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
 }
 
+@MainActor
 func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
     if waitForLoadingIndicator {
         Snapshot.snapshot(name)
@@ -33,6 +32,7 @@ func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
 /// - Parameters:
 ///   - name: The name of the snapshot
 ///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
 func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
     Snapshot.snapshot(name, timeWaitingForIdle: timeout)
 }
@@ -52,6 +52,7 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 }
 
 @objcMembers
+@MainActor
 open class Snapshot: NSObject {
     static var app: XCUIApplication?
     static var waitForAnimations = true
@@ -59,6 +60,8 @@ open class Snapshot: NSObject {
     static var screenshotsDirectory: URL? {
         return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
 
     open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
 
@@ -103,17 +106,17 @@ open class Snapshot: NSObject {
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
         } catch {
             NSLog("Couldn't detect/set locale...")
         }
 
-        if locale.isEmpty && !deviceLanguage.isEmpty {
-            locale = Locale(identifier: deviceLanguage).identifier
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
         }
 
-        if !locale.isEmpty {
-            app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
         }
     }
 
@@ -281,6 +284,7 @@ private extension XCUIElementQuery {
         return self.containing(isNetworkLoadingIndicator)
     }
 
+    @MainActor
     var deviceStatusBars: XCUIElementQuery {
         guard let app = Snapshot.app else {
             fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
@@ -306,4 +310,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.29]
+// SnapshotHelperVersion [1.30]

--- a/EZ Recipes/fastlane/changelogs/2.0.0.txt
+++ b/EZ Recipes/fastlane/changelogs/2.0.0.txt
@@ -1,0 +1,5 @@
+- Now you can search for recipes by name, calories, cuisines, and more with a dedicated search tab
+- Show messages while loading recipes
+- Show spice level, meal types, cuisines, and other facts for each recipe
+- Prevent recipe images from overlapping any content
+- Change the icon for the "I Made This!" button to match the other platforms

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Introducing EZ Recipes, an app that lets chefs find low-effort recipes that can 
 
 - iOS app created using SwiftUI and MVVM architecture
 - Responsive and accessible mobile design
-- REST APIs to a custom [server](https://github.com/Abhiek187/ez-recipes-server) using Alamofire, which fetches recipe information from [spoonacular](https://spoonacular.com/food-api)
+- REST APIs to a custom [server](https://github.com/Abhiek187/ez-recipes-server) using Alamofire, which fetches recipe information from [spoonacular](https://spoonacular.com/food-api) and MongoDB
 - Universal Links to open recipes from the web app to the mobile app
 - Automated testing and deployment using CI/CD pipelines in GitHub Actions and Fastlane
 - Mermaid to write diagrams as code
@@ -107,7 +107,7 @@ A Mac and Xcode are required to run iOS apps locally.
 3. Go to File --> Packages --> Resolve Package Versions to fetch all the Swift Package Manager dependencies.
 4. Run the **EZ Recipes** scheme.
 
-The recipes will be fetched from the EZ Recipes server hosted on https://ez-recipes-server.onrender.com/api/recipes. To connect to the server locally, follow the directions in the [EZ Recipes server repo](https://github.com/Abhiek187/ez-recipes-server#installing-locally) and change `recipeBaseUrl` under `Constants.swift` to `http://localhost:5000/api/recipes`.
+The recipes will be fetched from the EZ Recipes server hosted on https://ez-recipes-server.onrender.com/api/recipes. To connect to the server locally, follow the directions in the [EZ Recipes server repo](https://github.com/Abhiek187/ez-recipes-server#installing-locally) and change `serverBaseUrl` under `Constants.swift` to `http://localhost:5000`.
 
 ### Testing
 


### PR DESCRIPTION
Some fun facts I learned about the recipes stored in MongoDB while collecting all the screenshots (225 as of this writing):

- You can derive when recipes were stored using `_id`, and yeah, most of them come from weekend evenings!
- 89% of recipes come from Foodista
- Most recipes have a `healthScore` below 5
- All recipes have an average of:
  - 0.5 cuisines (min 0, max 4)
  - 11 ingredients (min 3, max 24)
    - The most common ingredient is flour, followed by salt and lemon juice
  - 1 instruction (min 0, max 3), with 6 average steps (min 0, max 28)
    - Ovens, bowls, and frying pans are the most common equipment
    - Flour and chicken are the most common ingredients for each step
  - 9 nutrients (5% are missing fiber)
  - 4 meal types (min 0, max 11)
- So far, no recipes are considered cheap or sustainable, according to spoonacular
- Half the recipes are gluten-free
- Only 5% are considered healthy
- 12% are vegan
- 43% are vegetarian
- 25% of recipes can serve 10 or more people!
- 82% of recipes have no spice, 11% are mild, and 7% are spicy
- 84% of recipes take 45 minutes to make

Side note: I intended to update the screenshots in this PR, but I'm not able to frame iPhone 14 screenshots just yet. Even though it's supported in [frameit](https://github.com/fastlane/fastlane/blob/master/frameit/lib/frameit/device_types.rb), the change was recent and Fastlane hasn't released a new version yet. I guess it'll also be good to wait in case I plan to make any more updates.