### PR TITLE
Feature/terms

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		F1F38EC3290F509B000FF99C /* Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F38EC2290F509B000FF99C /* Step.swift */; };
 		F1F38EC5290F50A9000FF99C /* StepItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F38EC4290F50A9000FF99C /* StepItem.swift */; };
 		F1F38ED0290F6962000FF99C /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F38ECF290F6962000FF99C /* SnapshotHelper.swift */; };
+		F1FB91592C08C13600DF3669 /* TermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB91582C08C13600DF3669 /* TermStore.swift */; };
+		F1FB915B2C08C3E600DF3669 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */; };
+		F1FB915F2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -169,6 +172,9 @@
 		F1F38ECE290F6923000FF99C /* Snapfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Snapfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F1F38ECF290F6962000FF99C /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
 		F1F38ED4290F773E000FF99C /* fastlane.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = fastlane.yml; sourceTree = "<group>"; };
+		F1FB91582C08C13600DF3669 /* TermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermStore.swift; sourceTree = "<group>"; };
+		F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -268,6 +274,7 @@
 				F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */,
 				F17A80AA2B7966B100E811C8 /* CaseIterableExtensionTests.swift */,
 				F1BD63A42B81605800B704AD /* RecipeFilterEncoderTests.swift */,
+				F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */,
 			);
 			path = "EZ RecipesTests";
 			sourceTree = "<group>";
@@ -296,6 +303,7 @@
 				F1F38EC2290F509B000FF99C /* Step.swift */,
 				F1F38EC4290F50A9000FF99C /* StepItem.swift */,
 				F1C7DA082B6F386800D6E343 /* Term.swift */,
+				F1FB91582C08C13600DF3669 /* TermStore.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -335,6 +343,7 @@
 				F123A845293D85CE00C8E127 /* DoubleExtension.swift */,
 				F17A80A82B795F0A00E811C8 /* CaseIterableExtension.swift */,
 				F11D3E942BC1A26F00BE5259 /* BoolExtension.swift */,
+				F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -571,6 +580,7 @@
 			files = (
 				F1C7DA0F2B70316400D6E343 /* RecipePills.swift in Sources */,
 				F1F38EB9290F3020000FF99C /* AFLogger.swift in Sources */,
+				F1FB915B2C08C3E600DF3669 /* UserDefaultsManager.swift in Sources */,
 				F12C1C632904CED500C3302B /* NetworkManager.swift in Sources */,
 				F1437C042956681C005408E5 /* StepCard.swift in Sources */,
 				F15CB9F22B770F610031F725 /* SearchResults.swift in Sources */,
@@ -582,6 +592,7 @@
 				F12C1C2D2904951600C3302B /* HomeView.swift in Sources */,
 				F1C7DA0B2B6F3AC100D6E343 /* RecipeFilter.swift in Sources */,
 				F1F38EC1290F5088000FF99C /* Instruction.swift in Sources */,
+				F1FB91592C08C13600DF3669 /* TermStore.swift in Sources */,
 				F122BBC82B8AB6EF00302FCA /* SearchSecondaryView.swift in Sources */,
 				F1F38EC3290F509B000FF99C /* Step.swift in Sources */,
 				F15CB9E82B75A6470031F725 /* ContentView.swift in Sources */,
@@ -627,6 +638,7 @@
 			files = (
 				F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */,
 				F17A80AB2B7966B100E811C8 /* CaseIterableExtensionTests.swift in Sources */,
+				F1FB915F2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift in Sources */,
 				F1BD63A52B81605800B704AD /* RecipeFilterEncoderTests.swift in Sources */,
 				F1F38EBB290F3751000FF99C /* HomeViewModelTests.swift in Sources */,
 				F122BBC42B899C2000302FCA /* SearchViewModelTests.swift in Sources */,

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		F1FB91592C08C13600DF3669 /* TermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB91582C08C13600DF3669 /* TermStore.swift */; };
 		F1FB915B2C08C3E600DF3669 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */; };
 		F1FB915F2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */; };
+		F1FB91622C08FD5700DF3669 /* GlossaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FB91612C08FD5700DF3669 /* GlossaryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -175,6 +176,7 @@
 		F1FB91582C08C13600DF3669 /* TermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermStore.swift; sourceTree = "<group>"; };
 		F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManagerTests.swift; sourceTree = "<group>"; };
+		F1FB91612C08FD5700DF3669 /* GlossaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlossaryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -312,6 +314,7 @@
 			isa = PBXGroup;
 			children = (
 				F15CB9E72B75A6470031F725 /* ContentView.swift */,
+				F1FB91602C08FD4100DF3669 /* Glossary */,
 				F1E0FD3F293D23600007255F /* Home */,
 				F1E0FD40293D236E0007255F /* Recipe */,
 				F15CB9E32B75A4D00031F725 /* Search */,
@@ -437,6 +440,14 @@
 				F1F38ED4290F773E000FF99C /* fastlane.yml */,
 			);
 			path = workflows;
+			sourceTree = "<group>";
+		};
+		F1FB91602C08FD4100DF3669 /* Glossary */ = {
+			isa = PBXGroup;
+			children = (
+				F1FB91612C08FD5700DF3669 /* GlossaryView.swift */,
+			);
+			path = Glossary;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -590,6 +601,7 @@
 				F1437C0929567211005408E5 /* InstructionsList.swift in Sources */,
 				F1F38EC5290F50A9000FF99C /* StepItem.swift in Sources */,
 				F12C1C2D2904951600C3302B /* HomeView.swift in Sources */,
+				F1FB91622C08FD5700DF3669 /* GlossaryView.swift in Sources */,
 				F1C7DA0B2B6F3AC100D6E343 /* RecipeFilter.swift in Sources */,
 				F1F38EC1290F5088000FF99C /* Instruction.swift in Sources */,
 				F1FB91592C08C13600DF3669 /* TermStore.swift in Sources */,

--- a/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
+++ b/EZ Recipes/EZ Recipes/EZ_RecipesApp.swift
@@ -18,6 +18,9 @@ struct EZ_RecipesApp: App {
                 .onOpenURL { url in
                     homeViewModel.handleRecipeLink(url)
                 }
+                .onAppear {
+                    homeViewModel.checkCachedTerms()
+                }
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -52,8 +52,9 @@ struct Constants {
     }
     
     struct Tabs {
-        static let home = "Home"
-        static let search = "Search"
+        static let home = Label("Home", systemImage: "house")
+        static let search = Label("Search", systemImage: "magnifyingglass")
+        static let glossary = Label("Glossary", systemImage: "book")
     }
     
     struct KeyboardNavigation {
@@ -167,5 +168,9 @@ struct Constants {
         
         // Results
         static let resultsTitle = "Results"
+    }
+    
+    struct GlossaryView {
+        static let glossaryTitle = "Glossary"
     }
 }

--- a/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
@@ -26,10 +26,9 @@ struct UserDefaultsManager {
             return nil
         }
         
-        // Delete the terms if they're expired
+        // Replace the terms if they're expired
         if Date().timeIntervalSince1970 >= termStore.expireAt {
             logger.debug("Cached terms have expired, retrieving a new set of terms...")
-            userDefaults.removeObject(forKey: Keys.terms)
             return nil
         }
         

--- a/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
@@ -19,7 +19,12 @@ struct UserDefaultsManager {
     }
     
     static func getTerms() -> [Term]? {
-        guard let termStorePlist = userDefaults.value(forKey: Keys.terms) as? Data, let termStore = try? PropertyListDecoder().decode(TermStore.self, from: termStorePlist) else { return nil }
+        guard let termStorePlist = userDefaults.value(forKey: Keys.terms) as? Data else { return nil }
+        guard let termStore = try? PropertyListDecoder().decode(TermStore.self, from: termStorePlist) else {
+            logger.warning("Stored terms are corrupted, deleting them and retrieving a new set of terms...")
+            userDefaults.removeObject(forKey: Keys.terms)
+            return nil
+        }
         
         // Delete the terms if they're expired
         if Date().timeIntervalSince1970 >= termStore.expireAt {

--- a/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
@@ -1,0 +1,48 @@
+//
+//  UserDefaultsManager.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 5/30/24.
+//
+
+import Foundation
+import OSLog
+
+/// Helper methods for UserDefaults
+///
+/// - Note: UserDefaults stored at ~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Preferences
+struct UserDefaultsManager {
+    private static let userDefaults = UserDefaults.standard
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "UserDefaultsManager")
+    private struct Keys {
+        static let terms = "terms"
+    }
+    
+    static func getTerms() -> [Term]? {
+        guard let termStorePlist = userDefaults.value(forKey: Keys.terms) as? Data, let termStore = try? PropertyListDecoder().decode(TermStore.self, from: termStorePlist) else { return nil }
+        
+        // Delete the terms if they're expired
+        if Date().timeIntervalSince1970 >= termStore.expireAt {
+            logger.debug("Cached terms have expired, retrieving a new set of terms...")
+            userDefaults.removeObject(forKey: Keys.terms)
+            return nil
+        }
+        
+        return termStore.terms
+    }
+    
+    static func saveTerms(terms: [Term]) {
+        guard let oneWeek = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: Date()) else {
+            logger.warning("Failed to add 1 week to the current date")
+            return
+        }
+        
+        let termStore = TermStore(terms: terms, expireAt: oneWeek.timeIntervalSince1970)
+        guard let termStorePlist = try? PropertyListEncoder().encode(termStore) else {
+            logger.warning("Couldn't encode termStore to a property list: \(String(describing: termStore))")
+            return
+        }
+        userDefaults.set(termStorePlist, forKey: Keys.terms)
+        logger.debug("Saved terms to UserDefaults!")
+    }
+}

--- a/EZ Recipes/EZ Recipes/Models/Term.swift
+++ b/EZ Recipes/EZ Recipes/Models/Term.swift
@@ -5,7 +5,7 @@
 //  Created by Abhishek Chaudhuri on 2/3/24.
 //
 
-struct Term: Decodable {
+struct Term: Codable {
     let _id: String
     let word: String
     let definition: String

--- a/EZ Recipes/EZ Recipes/Models/TermStore.swift
+++ b/EZ Recipes/EZ Recipes/Models/TermStore.swift
@@ -1,0 +1,13 @@
+//
+//  TermStore.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 5/30/24.
+//
+
+import Foundation
+
+struct TermStore: Codable {
+    let terms: [Term]
+    let expireAt: TimeInterval
+}

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -12,11 +12,15 @@ struct ContentView: View {
         TabView {
             HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
                 .tabItem {
-                    Label(Constants.Tabs.home, systemImage: "house")
+                    Constants.Tabs.home
                 }
             SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
                 .tabItem {
-                    Label(Constants.Tabs.search, systemImage: "magnifyingglass")
+                    Constants.Tabs.search
+                }
+            GlossaryView()
+                .tabItem {
+                    Constants.Tabs.glossary
                 }
         }
     }

--- a/EZ Recipes/EZ Recipes/Views/Glossary/GlossaryView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Glossary/GlossaryView.swift
@@ -1,0 +1,33 @@
+//
+//  GlossaryView.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 5/30/24.
+//
+
+import SwiftUI
+
+struct GlossaryView: View {
+    var body: some View {
+        NavigationStack {
+            if let terms = UserDefaultsManager.getTerms()?.sorted(by: {
+                // Sort all the terms alphabetically for ease of reference
+                $0.word < $1.word
+            }) {
+                List(terms, id: \._id) { term in
+                    Text("**\(term.word)** — \(term.definition)")
+                }
+                // Prevent the list from overlapping the status bar
+                .navigationTitle(Constants.GlossaryView.glossaryTitle)
+            }
+        }
+    }
+}
+
+struct GlossaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        UserDefaultsManager.saveTerms(terms: Constants.Mocks.terms)
+        
+        return GlossaryView()
+    }
+}

--- a/EZ Recipes/EZ Recipes/Views/Glossary/GlossaryView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Glossary/GlossaryView.swift
@@ -8,17 +8,29 @@
 import SwiftUI
 
 struct GlossaryView: View {
+    @State var terms = UserDefaultsManager.getTerms()?.sorted(by: {
+        // Sort all the terms alphabetically for ease of reference
+        $0.word < $1.word
+    })
+    
     var body: some View {
         NavigationStack {
-            if let terms = UserDefaultsManager.getTerms()?.sorted(by: {
-                // Sort all the terms alphabetically for ease of reference
-                $0.word < $1.word
-            }) {
-                List(terms, id: \._id) { term in
-                    Text("**\(term.word)** — \(term.definition)")
+            Group {
+                if let terms {
+                    List(terms, id: \._id) { term in
+                        Text("**\(term.word)** — \(term.definition)")
+                    }
+                } else {
+                    // Show that the terms are loading
+                    ProgressView()
                 }
-                // Prevent the list from overlapping the status bar
-                .navigationTitle(Constants.GlossaryView.glossaryTitle)
+            }
+            .navigationTitle(Constants.GlossaryView.glossaryTitle)
+        }
+        .onAppear {
+            // Update the terms list when switching tabs
+            terms = UserDefaultsManager.getTerms()?.sorted {
+                $0.word < $1.word
             }
         }
     }

--- a/EZ Recipes/EZ RecipesTests/UserDefaultsManagerTests.swift
+++ b/EZ Recipes/EZ RecipesTests/UserDefaultsManagerTests.swift
@@ -1,0 +1,26 @@
+//
+//  UserDefaultsManagerTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 5/30/24.
+//
+
+import XCTest
+@testable import EZ_Recipes
+
+final class UserDefaultsManagerTests: XCTestCase {
+    func testSaveTerms() {
+        // Given terms
+        let mockTerms = Constants.Mocks.terms.sorted { $0._id < $1._id }
+        
+        // When saved to UserDefaults
+        UserDefaultsManager.saveTerms(terms: mockTerms)
+        
+        // Then they should be able to be retrieved
+        let storedTerms = UserDefaultsManager.getTerms()?.sorted { $0._id < $1._id }
+        XCTAssertNotNil(storedTerms)
+        XCTAssert(storedTerms!.elementsEqual(mockTerms) {
+            $0._id == $1._id && $0.word == $1.word && $0.definition == $1.definition
+        })
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,15 +15,20 @@
 
 ## Overview
 
-Cooking food at home is an essential skill for anyone looking to save money and eat healthily. However, learning how to cook can be daunting, since there are so many recipes to choose from. And even when meal prepping, knowing what ingredients to buy, what equipment is required, and the order of steps to make the meal can be hard to remember for many different recipes. Plus, during busy days, it's nice to be able to cook up something quick and tasty.
+Cooking food at home is an essential skill for anyone looking to save money and eat healthily. However, learning how to cook can be daunting, since there are so many recipes to choose from. Even when meal prepping, knowing what ingredients to buy, what equipment is required, and the order of steps to make the meal can be hard to remember for many different recipes. Plus, during busy days, it's nice to be able to cook up something quick and tasty.
 
 Introducing EZ Recipes, an app that lets chefs find low-effort recipes that can be made in under an hour, use common kitchen ingredients, and can produce multiple servings. On one page, chefs can view what the recipe looks like, its nutritional qualities, the total cooking time, all the ingredients needed, and step-by-step instructions showing what ingredients and equipment are required per step. Each recipe can be shared so other chefs can learn how to make the same recipes.
+
+Chefs can either find a random recipe or search for one using various filters, including by name, dietary restrictions, spice level, and meal type.
+
+The app features a glossary to easily lookup the meaning of common terms found in recipes. This will better assist newer chefs in learning how to cook, prep certain ingredients, and use certain kitchen tools. Think How to Stock, but for cooking food instead of managing finances.
 
 ## Features
 
 - iOS app created using SwiftUI and MVVM architecture
 - Responsive and accessible mobile design
 - REST APIs to a custom [server](https://github.com/Abhiek187/ez-recipes-server) using Alamofire, which fetches recipe information from [spoonacular](https://spoonacular.com/food-api) and MongoDB
+- Offline data storage using UserDefaults and Core Data
 - Universal Links to open recipes from the web app to the mobile app
 - Automated testing and deployment using CI/CD pipelines in GitHub Actions and Fastlane
 - Mermaid to write diagrams as code


### PR DESCRIPTION
![Simulator Screenshot - iPhone 15 Pro - 2024-05-30 at 18 38 03](https://github.com/Abhiek187/ez-recipes-ios/assets/29958092/d4fca8ad-bbcd-4159-8b5a-a28ee57e38c5)

_The iOS implemenation of https://github.com/Abhiek187/ez-recipes-web/issues/12_

I stored all the terms in UserDefaults and encoded them as a plist instead of JSON since it's faster and more native to iOS. I realized while working on this that I shouldn't necessarily delete the terms if they're expired. I can just replace them when next retrieved by the API. Because of the slow cool starts, I don't want the user to question why their glossary page is suddenly blank after not using the app for a week. It's more seamless to just update the list when switching tabs. I applied this same change to the web app as well.

We will update the screenshots once all the other features are implemented.