### PR TITLE
Disable automatic package resolution

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
       - if: matrix.language == 'swift'
         run: |
           echo "Run, Build Application using script"
-          /Applications/Xcode_15.3.app/Contents/Developer/usr/bin/xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+          /Applications/Xcode_15.3.app/Contents/Developer/usr/bin/xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" -disableAutomaticPackageResolution CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Let's see if `-disableAutomaticPackageResolution` will save a few minutes on compiling for CodeQL. **Edit:** no it's still slower than the Fastlane builds, but still a nice flag to add