### PR TITLE
Nav Fix

### DIFF
--- a/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/RecipeView.swift
@@ -13,7 +13,8 @@ struct RecipeView: View {
     @State var isFavorite = false
     @State var shareText: ShareText?
     
-    @Environment(\.horizontalSizeClass) var sizeClass
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         ScrollView {
@@ -60,7 +61,12 @@ struct RecipeView: View {
                     
                     RecipeFooter()
                 } else {
-                    Text(Constants.RecipeView.noRecipe) // shouldn't be seen normally
+                    // Shouldn't be seen normally
+                    Text(Constants.RecipeView.noRecipe)
+                        .onAppear {
+                            // Pop to the search results if editing the filter form from the sidebar
+                            dismiss()
+                        }
                 }
             }
         }

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -16,6 +16,7 @@ struct FilterForm: View {
         case maxCals
     }
     
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @ObservedObject var viewModel: SearchViewModel
     
     @FocusState private var focusedField: Field?
@@ -118,8 +119,13 @@ struct FilterForm: View {
             }
         }
         // Prevent navigation unless the recipes are loaded
+        .onAppear {
+            if sizeClass == .compact {
+                viewModel.isRecipeLoaded = false
+            }
+        }
         // Must place navigationDestination outside lazy containers (Form is rendered as a List)
-        .navigationDestination(isPresented: (!viewModel.recipes.isEmpty).binding()) {
+        .navigationDestination(isPresented: viewModel.isRecipeLoaded.binding()) {
             SearchResults(recipes: viewModel.recipes, searchViewModel: viewModel)
         }
         .toolbar {

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -16,7 +16,6 @@ struct FilterForm: View {
         case maxCals
     }
     
-    @Environment(\.horizontalSizeClass) private var sizeClass
     @ObservedObject var viewModel: SearchViewModel
     
     @FocusState private var focusedField: Field?
@@ -120,7 +119,7 @@ struct FilterForm: View {
         }
         // Prevent navigation unless the recipes are loaded
         .onAppear {
-            if sizeClass == .compact {
+            if UIDevice.current.userInterfaceIdiom == .phone {
                 viewModel.isRecipeLoaded = false
             }
         }

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -117,6 +117,11 @@ struct FilterForm: View {
                 FormError(on: noRecipesFound, message: Constants.SearchView.noResults)
             }
         }
+        // Prevent navigation unless the recipes are loaded
+        // Must place navigationDestination outside lazy containers (Form is rendered as a List)
+        .navigationDestination(isPresented: (!viewModel.recipes.isEmpty).binding()) {
+            SearchResults(recipes: viewModel.recipes, searchViewModel: viewModel)
+        }
         .toolbar {
             // Add buttons above the keyboard for ease of navigation
             ToolbarItem(placement: .keyboard) {

--- a/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
@@ -28,10 +28,6 @@ struct SubmitButton: View {
                     Text(viewModel.recipeError?.error ?? Constants.unknownError)
                 }
                 .padding(.trailing)
-                // Prevent navigation unless the recipes are loaded
-                .navigationDestination(isPresented: (!viewModel.recipes.isEmpty).binding()) {
-                    SearchResults(recipes: viewModel.recipes, searchViewModel: viewModel)
-                }
                 
                 ProgressView()
                     .opacity(viewModel.isLoading ? 1 : 0)


### PR DESCRIPTION
I finally fixed (most of) the navigation bugs! Instead of using the router pattern (`NavigationPath`), I modified the condition to show the search results and placed it outside the form to prevent that other error from appearing. On small screens, you can go back to the filter form and modify any of the fields without navigating back to the results. On large screens, if you view the recipe page and then modify the form, it will pop back to the results.

The only other bug I noticed is that on large screens, if you navigate to the search results, you won't be able to modify the picker fields. A workaround is to modify the filters to show no results and then select the pickers. I _can_ fix this by popping all the way back to the secondary view, but you'd lose the ability to view other recipes while modifying the form.