### PR TITLE
Feature/review

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/toastersocks/MultiPicker.git",
       "state" : {
-        "revision" : "4c625e168c4de1b3aead29fcefa91d1108094022",
-        "version" : "1.0.6"
+        "revision" : "bd217fcdbd39969b6b42126565a077702a0f0015",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct Constants {
+    static let recipesToPresentReview = 5
+    
     // Common strings
     static let appName = "EZ Recipes"
     static let errorTitle = "Error"

--- a/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
@@ -11,12 +11,14 @@ import OSLog
 /// Helper methods for UserDefaults
 ///
 /// - Note: UserDefaults stored at ~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Preferences
-/// (/var/mobile/Containers/... on real devices) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`)
+/// (/var/mobile/Containers/... on real devices) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`) (view plist file by running `/usr/libexec/PlistBuddy -c print PLIST-FILE`)
 struct UserDefaultsManager {
     private static let userDefaults = UserDefaults.standard
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "UserDefaultsManager")
-    private struct Keys {
+    struct Keys {
         static let terms = "terms"
+        static let recipesViewed = "recipesViewed"
+        static let lastVersionPromptedForReview = "lastVersionPromptedForReview"
     }
     
     static func getTerms() -> [Term]? {
@@ -49,5 +51,10 @@ struct UserDefaultsManager {
         }
         userDefaults.set(termStorePlist, forKey: Keys.terms)
         logger.debug("Saved terms to UserDefaults!")
+    }
+    
+    static func incrementRecipesViewed() {
+        let recipesViewed = userDefaults.integer(forKey: Keys.recipesViewed)
+        userDefaults.set(recipesViewed + 1, forKey: Keys.recipesViewed)
     }
 }

--- a/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/HomeViewModel.swift
@@ -20,6 +20,10 @@ class HomeViewModel: ViewModel, ObservableObject {
         didSet {
             isRecipeLoaded = recipe != nil
             saveRecentRecipe()
+            
+            if recipe != nil {
+                UserDefaultsManager.incrementRecipesViewed()
+            }
         }
     }
     

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
+            // TODO: Replace .tabItem with Tab() for iOS 18.0+
             HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
                 .tabItem {
                     Constants.Tabs.home

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -34,6 +34,7 @@ struct HomeView: View {
                             .foregroundStyle(viewModel.isLoading ? Color.primary : .black)
                             .font(.system(size: 22))
                     }
+                    .padding(.top)
                     .buttonStyle(.borderedProminent)
                     .tint(.yellow)
                     // Prevent users from spamming the button


### PR DESCRIPTION
<div>
  <img src="https://github.com/Abhiek187/ez-recipes-ios/assets/29958092/d76b13f7-748a-4379-892f-9ab561e45c54" alt="review-prompt-1" width="300">
  <img src="https://github.com/Abhiek187/ez-recipes-ios/assets/29958092/28fd6b11-e30b-4bff-a627-4c35be08091f" alt="review-prompt-2" width="300">
</div>

_The iOS implementation of https://github.com/Abhiek187/ez-recipes-android/issues/97_

To help collect feedback, a review prompt will now appear on the home screen after viewing at least 5 recipes. Since this prompt can only appear up to 3 times per 365-day period, I only show it once per app version. There's a 2-second delay to reduce the chances of it interrupting the user. It works in the simulator, but the submit button is grayed out since the app isn't published.

This shouldn't appear in UI tests since we're not opening this many recipes.

Sample UserDefaults (from running `/usr/libexec/PlistBuddy -c print com.abhiek.EZ-Recipes.plist`):
```
Dict {
    terms = bplist00?termsXexpireAt?
                                    ?
S_idTwordZdefinition_659355351c9a1fbc3bce6618Wproduce_food grown by farming?
_6593556d1c9a1fbc3bce6619Umince_cut up into small pieces?_659355831c9a1fbc3bce661aUbroil_cook, such as in an oven?_659355951c9a1fbc3bce661bVsimmer_<stay below the boiling point when heated, such as with water?_659355a41c9a1fbc3bce661cXal de")-2=X`x??????? 'fm????asta or rice that's cooked so it can be chewed#Aٜ?f۠I
    recipesViewed = 10
    lastVersionPromptedForReview = 2.0.1
}
```