### PR TITLE
Xcode 16 Upgrades

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
       - if: matrix.language == 'swift'
         run: |
           echo "Run, Build Application using script"
-          set -o pipefail && env NSUnbufferedIO=YES /Applications/Xcode_15.3.app/Contents/Developer/usr/bin/xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" -disableAutomaticPackageResolution CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" -disableAutomaticPackageResolution CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		F1E0FD44293D24CF0007255F /* RecipeHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E0FD43293D24CF0007255F /* RecipeHeader.swift */; };
 		F1E0FD48293D73B20007255F /* RecipeFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E0FD47293D73B20007255F /* RecipeFooter.swift */; };
 		F1E0FD4A293D753C0007255F /* NutritionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E0FD49293D753C0007255F /* NutritionLabel.swift */; };
+		F1E5A0672C9E36D700594331 /* DoubleExtensionTests2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E5A0662C9E36D700594331 /* DoubleExtensionTests2.swift */; };
 		F1EAC7F129217E250046B268 /* RecipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EAC7F029217E250046B268 /* RecipeView.swift */; };
 		F1EAC7F4292185B90046B268 /* RecipeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EAC7F3292185B90046B268 /* RecipeRepository.swift */; };
 		F1EAC7F6292185D70046B268 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EAC7F5292185D70046B268 /* ViewModel.swift */; };
@@ -168,6 +169,7 @@
 		F1E0FD47293D73B20007255F /* RecipeFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeFooter.swift; sourceTree = "<group>"; };
 		F1E0FD49293D753C0007255F /* NutritionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionLabel.swift; sourceTree = "<group>"; };
 		F1E48B0E2B8BCA4500A40169 /* 2.0.0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = 2.0.0.txt; sourceTree = "<group>"; };
+		F1E5A0662C9E36D700594331 /* DoubleExtensionTests2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensionTests2.swift; sourceTree = "<group>"; };
 		F1EAC7EA29216F350046B268 /* NetworkManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerMock.swift; sourceTree = "<group>"; };
 		F1EAC7F029217E250046B268 /* RecipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeView.swift; sourceTree = "<group>"; };
 		F1EAC7F3292185B90046B268 /* RecipeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeRepository.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 			children = (
 				F1BD63A42B81605800B704AD /* RecipeFilterEncoderTests.swift */,
 				F123A847293D88A100C8E127 /* DoubleExtensionTests.swift */,
+				F1E5A0662C9E36D700594331 /* DoubleExtensionTests2.swift */,
 				F17A80AA2B7966B100E811C8 /* CaseIterableExtensionTests.swift */,
 				F16A84212C51BEEE000AED74 /* StringExtensionTests.swift */,
 				F1BB7D3F2C167F0A00E129AC /* CodableExtensionTests.swift */,
@@ -684,6 +687,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */,
+				F1E5A0672C9E36D700594331 /* DoubleExtensionTests2.swift in Sources */,
 				F17A80AB2B7966B100E811C8 /* CaseIterableExtensionTests.swift in Sources */,
 				F16A84222C51BEEF000AED74 /* StringExtensionTests.swift in Sources */,
 				F1FB915F2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift in Sources */,

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -550,7 +550,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1520;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					F12C1C262904951600C3302B = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -911,7 +911,6 @@
 		F12C1C4F2904951B00C3302B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -931,7 +930,6 @@
 		F12C1C502904951B00C3302B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -951,7 +949,6 @@
 		F12C1C522904951B00C3302B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UF6E5BVT98;
@@ -969,7 +966,6 @@
 		F12C1C532904951B00C3302B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UF6E5BVT98;

--- a/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ Recipes.xcscheme
+++ b/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ Recipes.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ RecipesUITests.xcscheme
+++ b/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ RecipesUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -9,41 +9,20 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        if #available(iOS 18.0, *) {
-            TabView {
-                Tab {
-                    HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
-                } label: {
+        TabView {
+            // TODO: Replace .tabItem with Tab() for iOS 18.0+
+            HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
+                .tabItem {
                     Constants.Tabs.home
                 }
-                
-                Tab {
-                    SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
-                } label: {
+            SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
+                .tabItem {
                     Constants.Tabs.search
                 }
-                
-                Tab {
-                    GlossaryView()
-                } label: {
+            GlossaryView()
+                .tabItem {
                     Constants.Tabs.glossary
                 }
-            }
-        } else {
-            TabView {
-                HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
-                    .tabItem {
-                        Constants.Tabs.home
-                    }
-                SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
-                    .tabItem {
-                        Constants.Tabs.search
-                    }
-                GlossaryView()
-                    .tabItem {
-                        Constants.Tabs.glossary
-                    }
-            }
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -9,20 +9,41 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        TabView {
-            // TODO: Replace .tabItem with Tab() for iOS 18.0+
-            HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
-                .tabItem {
+        if #available(iOS 18.0, *) {
+            TabView {
+                Tab {
+                    HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
+                } label: {
                     Constants.Tabs.home
                 }
-            SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
-                .tabItem {
+                
+                Tab {
+                    SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
+                } label: {
                     Constants.Tabs.search
                 }
-            GlossaryView()
-                .tabItem {
+                
+                Tab {
+                    GlossaryView()
+                } label: {
                     Constants.Tabs.glossary
                 }
+            }
+        } else {
+            TabView {
+                HomeView(viewModel: HomeViewModel(repository: NetworkManager.shared))
+                    .tabItem {
+                        Constants.Tabs.home
+                    }
+                SearchView(viewModel: SearchViewModel(repository: NetworkManager.shared))
+                    .tabItem {
+                        Constants.Tabs.search
+                    }
+                GlossaryView()
+                    .tabItem {
+                        Constants.Tabs.glossary
+                    }
+            }
         }
     }
 }

--- a/EZ Recipes/EZ Recipes/Views/Recipe/NutritionLabel.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/NutritionLabel.swift
@@ -37,7 +37,6 @@ struct NutritionLabel: View {
                         Text("\(nutrient.amount.round()) \(nutrient.unit)")
                             .multilineTextAlignment(.trailing)
                     }
-                    // .bold(condition) and .fontWeight are only available on iOS 16
                     .font(.body.weight(nutrientHeadings.contains(nutrient.name) ? .bold : .regular))
                 }
             }

--- a/EZ Recipes/EZ RecipesTests/Helpers/DoubleExtensionTests2.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/DoubleExtensionTests2.swift
@@ -5,23 +5,25 @@
 //  Created by Abhishek Chaudhuri on 9/20/24.
 //
 
-import Testing
-@testable import EZ_Recipes
-
-struct DoubleExtensionTests2 {
-    @Test("Rounding numbers", arguments: [
-        (0, 0, "0"),
-        (0, 2, "0"),
-        (0.2, 0, "0"),
-        (0.2500000, 2, "0.25"),
-        (0.3000001, 1, "0.3"),
-        (0.5, 0, "1"),
-        (1.5, 0, "2"),
-        (3.1415927, 3, "3.142"),
-        (-53.24, 1, "-53.2"),
-        (1029.529732, 0, "1,030"),
-        (1029.529732, 4, "1,029.5297")
-    ]) func round(input: Double, places: Int, expectedOutput: String) async throws {
-        #expect(input.round(to: places) == expectedOutput)
-    }
-}
+// Uncomment once Xcode 16 becomes the default on GitHub Actions:
+// https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+//import Testing
+//@testable import EZ_Recipes
+//
+//struct DoubleExtensionTests2 {
+//    @Test("Rounding numbers", arguments: [
+//        (0, 0, "0"),
+//        (0, 2, "0"),
+//        (0.2, 0, "0"),
+//        (0.2500000, 2, "0.25"),
+//        (0.3000001, 1, "0.3"),
+//        (0.5, 0, "1"),
+//        (1.5, 0, "2"),
+//        (3.1415927, 3, "3.142"),
+//        (-53.24, 1, "-53.2"),
+//        (1029.529732, 0, "1,030"),
+//        (1029.529732, 4, "1,029.5297")
+//    ]) func round(input: Double, places: Int, expectedOutput: String) async throws {
+//        #expect(input.round(to: places) == expectedOutput)
+//    }
+//}

--- a/EZ Recipes/EZ RecipesTests/Helpers/DoubleExtensionTests2.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/DoubleExtensionTests2.swift
@@ -1,0 +1,27 @@
+//
+//  DoubleExtensionTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 9/20/24.
+//
+
+import Testing
+@testable import EZ_Recipes
+
+struct DoubleExtensionTests2 {
+    @Test("Rounding numbers", arguments: [
+        (0, 0, "0"),
+        (0, 2, "0"),
+        (0.2, 0, "0"),
+        (0.2500000, 2, "0.25"),
+        (0.3000001, 1, "0.3"),
+        (0.5, 0, "1"),
+        (1.5, 0, "2"),
+        (3.1415927, 3, "3.142"),
+        (-53.24, 1, "-53.2"),
+        (1029.529732, 0, "1,030"),
+        (1029.529732, 4, "1,029.5297")
+    ]) func round(input: Double, places: Int, expectedOutput: String) async throws {
+        #expect(input.round(to: places) == expectedOutput)
+    }
+}

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -28,6 +28,17 @@ class EZ_RecipesUITests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
+    
+    private func goTo(tab: String) {
+        // On iPadOS 18+, the tab bars are floating tab buttons
+        let tabBar = app.tabBars["Tab Bar"]
+        
+        if tabBar.exists {
+            tabBar.buttons[tab].tap()
+        } else {
+            app.buttons[tab].tap()
+        }
+    }
 
     @MainActor
     func testFindMeARecipe() throws {
@@ -148,7 +159,7 @@ class EZ_RecipesUITests: XCTestCase {
     @MainActor
     func testSearchRecipes() throws {
         // Go to the Search tab
-        app.tabBars["Tab Bar"].buttons["Search"].tap()
+        goTo(tab: "Search")
         var shotNum = 1
         snapshot("search-view-\(shotNum)")
         shotNum += 1
@@ -339,7 +350,7 @@ class EZ_RecipesUITests: XCTestCase {
     @MainActor
     func testGlossaryScreen() throws {
         // Take a screenshot of the glossary tab (no assertions)
-        app.tabBars["Tab Bar"].buttons["Glossary"].tap()
+        goTo(tab: "Glossary")
         snapshot("glossary-view")
     }
 }

--- a/EZ Recipes/fastlane/Fastfile
+++ b/EZ Recipes/fastlane/Fastfile
@@ -25,8 +25,8 @@ platform :ios do
     # Only run in GitHub Actions
     if ENV["CI"]
       # Set the Xcode version before running each lane: /usr/local/bin/xcodes installed VERSION
-      xcodes(version: "15.3", # required to support Package.resolved version 3
-             select_for_current_build_only: true)
+#      xcodes(version: "15.3", # required to support Package.resolved version 3
+#             select_for_current_build_only: true)
     end
   end
   


### PR DESCRIPTION
![fancy-tabs-l](https://github.com/user-attachments/assets/0d651f9c-5c0d-4e27-81da-c52c416e2f5b)
![fancy-tabs-ls](https://github.com/user-attachments/assets/224c8d34-f44e-451d-bc83-4ab27047c35d)
![fancy-tabs-p](https://github.com/user-attachments/assets/014cbb5b-f829-458d-b18c-50dc9e375809)

We got some new fancy floating tab bars on iPadOS 18, which means adjusting our UI tests of course! I'm also going to check to see if Swift Testing works with the default Xcode 15.4 on the macOS runners, or if we need to wait until they're compatible with Swift 6.

**Edit:** Called it!
> Error: no such module 'Testing'
import Testing
       ^