### PR TITLE
Create a helper class for the Keychain

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		F17A80A92B795F0A00E811C8 /* CaseIterableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A80A82B795F0A00E811C8 /* CaseIterableExtension.swift */; };
 		F17A80AB2B7966B100E811C8 /* CaseIterableExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A80AA2B7966B100E811C8 /* CaseIterableExtensionTests.swift */; };
 		F17A80AF2B7978FD00E811C8 /* RecipeFilterEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A80AE2B7978FD00E811C8 /* RecipeFilterEncoder.swift */; };
+		F188E1DD2D0A328800A9D771 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F188E1DC2D0A328800A9D771 /* KeychainManager.swift */; };
+		F188E1DF2D0CDEC800A9D771 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F188E1DE2D0CDEC800A9D771 /* KeychainManagerTests.swift */; };
+		F188E1E12D0CE1B400A9D771 /* OSStatusExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F188E1E02D0CE1AD00A9D771 /* OSStatusExtension.swift */; };
 		F1BB7D342C14E28800E129AC /* EZ Recipes.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7D322C14E28800E129AC /* EZ Recipes.xcdatamodeld */; };
 		F1BB7D382C14F62C00E129AC /* RecentRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7D372C14F62B00E129AC /* RecentRecipe.swift */; };
 		F1BB7D3A2C14F88600E129AC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7D392C14F88600E129AC /* CoreDataManager.swift */; };
@@ -149,6 +152,9 @@
 		F17A80A82B795F0A00E811C8 /* CaseIterableExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseIterableExtension.swift; sourceTree = "<group>"; };
 		F17A80AA2B7966B100E811C8 /* CaseIterableExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseIterableExtensionTests.swift; sourceTree = "<group>"; };
 		F17A80AE2B7978FD00E811C8 /* RecipeFilterEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeFilterEncoder.swift; sourceTree = "<group>"; };
+		F188E1DC2D0A328800A9D771 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		F188E1DE2D0CDEC800A9D771 /* KeychainManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManagerTests.swift; sourceTree = "<group>"; };
+		F188E1E02D0CE1AD00A9D771 /* OSStatusExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSStatusExtension.swift; sourceTree = "<group>"; };
 		F19C387E2BD9B7CF0075D7F2 /* 2.0.1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = 2.0.1.txt; sourceTree = "<group>"; };
 		F1B6B4D12C1E6DB70058DCA7 /* 2.1.0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = 2.1.0.txt; sourceTree = "<group>"; };
 		F1BB7D332C14E28800E129AC /* EZ Recipes.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "EZ Recipes.xcdatamodel"; sourceTree = "<group>"; };
@@ -365,8 +371,10 @@
 				F11D3E942BC1A26F00BE5259 /* BoolExtension.swift */,
 				F1BB7D3B2C1505E700E129AC /* CodableExtension.swift */,
 				F16A841F2C51AE68000AED74 /* StringExtension.swift */,
+				F188E1E02D0CE1AD00A9D771 /* OSStatusExtension.swift */,
 				F1FB915A2C08C3E600DF3669 /* UserDefaultsManager.swift */,
 				F1BB7D392C14F88600E129AC /* CoreDataManager.swift */,
+				F188E1DC2D0A328800A9D771 /* KeychainManager.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -405,6 +413,7 @@
 				F1BB7D3F2C167F0A00E129AC /* CodableExtensionTests.swift */,
 				F1FB915E2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift */,
 				F1BB7D412C167F2200E129AC /* CoreDataManagerTests.swift */,
+				F188E1DE2D0CDEC800A9D771 /* KeychainManagerTests.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -637,6 +646,7 @@
 				F1437C0929567211005408E5 /* InstructionsList.swift in Sources */,
 				F1BB7D382C14F62C00E129AC /* RecentRecipe.swift in Sources */,
 				F1F38EC5290F50A9000FF99C /* StepItem.swift in Sources */,
+				F188E1E12D0CE1B400A9D771 /* OSStatusExtension.swift in Sources */,
 				F12C1C2D2904951600C3302B /* HomeView.swift in Sources */,
 				F1FB91622C08FD5700DF3669 /* GlossaryView.swift in Sources */,
 				F1C7DA0B2B6F3AC100D6E343 /* RecipeFilter.swift in Sources */,
@@ -655,6 +665,7 @@
 				F12C1C2B2904951600C3302B /* EZ_RecipesApp.swift in Sources */,
 				F1EAC7F6292185D70046B268 /* ViewModel.swift in Sources */,
 				F1EAC7F129217E250046B268 /* RecipeView.swift in Sources */,
+				F188E1DD2D0A328800A9D771 /* KeychainManager.swift in Sources */,
 				F1320CDA297C923B00070DC8 /* HomeSecondaryView.swift in Sources */,
 				F1F38EB7290F215C000FF99C /* HomeViewModel.swift in Sources */,
 				F15CB9F42B770F7F0031F725 /* RecipeCard.swift in Sources */,
@@ -689,6 +700,7 @@
 				F123A848293D88A100C8E127 /* DoubleExtensionTests.swift in Sources */,
 				F1E5A0672C9E36D700594331 /* DoubleExtensionTests2.swift in Sources */,
 				F17A80AB2B7966B100E811C8 /* CaseIterableExtensionTests.swift in Sources */,
+				F188E1DF2D0CDEC800A9D771 /* KeychainManagerTests.swift in Sources */,
 				F16A84222C51BEEF000AED74 /* StringExtensionTests.swift in Sources */,
 				F1FB915F2C08F7FF00DF3669 /* UserDefaultsManagerTests.swift in Sources */,
 				F1BD63A52B81605800B704AD /* RecipeFilterEncoderTests.swift in Sources */,

--- a/EZ Recipes/EZ Recipes/Helpers/CoreDataManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/CoreDataManager.swift
@@ -10,8 +10,8 @@ import OSLog
 
 /// Helper methods for Core Data
 ///
-/// - Note: Core Data stored at ~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Application Support
-/// (/var/mobile/Containers/... on real devices) (~/Library/Developer/Xcode/UserData/Previews/Simulator Devices/... in previews) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`)
+/// - Note: Core Data stored at `~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Application Support`
+/// (`/var/mobile/Containers/...` on real devices) (`~/Library/Developer/Xcode/UserData/Previews/Simulator Devices/...` in previews) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`)
 struct CoreDataManager {
     static let shared = CoreDataManager()
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "CoreDataManager")

--- a/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
@@ -1,0 +1,111 @@
+//
+//  SecureStoreError.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 12/11/24.
+//
+
+import Foundation
+import Security
+
+enum SecureStoreError: Error {
+    case invalidContent
+    case failure(error: NSError)
+}
+
+/// Helper methods for the Keychain
+///
+/// - Note: Keychain stored at `~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Library/Keychains`
+/// (`/var/Keychains` on real devices) (`~/Library/Developer/Xcode/UserData/Previews/Simulator Devices/...` in previews) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`)
+class KeychainManager {
+    static let shared = KeychainManager()
+    
+    private func setupQueryDictionary(forKey key: String) throws -> [CFString: Any] {
+        guard let keyData = key.data(using: .utf8) else {
+            print("Error! Could not convert the key to the expected format.")
+            throw SecureStoreError.invalidContent
+        }
+        
+        var error: Unmanaged<CFError>?
+        guard let accessControl = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            // Make the Keychain accessible only if the device has a passcode and is unlocked
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            // Require biometrics or a passcode to access
+            .userPresence,
+            &error
+        ) else {
+            print("Error! Could not create access control flags :: Error: \(String(describing: error))")
+            throw SecureStoreError.invalidContent
+        }
+        
+        // kSecClass defines the class of the keychain item
+        // We store user credentials in the keychain, so I use kSecClassGenericPassword for the value
+        // The kSecAttrAccount - keyData pair uniquely identify the account who will be accessing the keychain
+        return [
+            kSecClass: kSecClassGenericPassword, // genp table
+            kSecAttrAccount: keyData, // account == key
+//            kSecAttrAccessible: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            kSecAttrAccessControl: accessControl
+        ]
+    }
+    
+    func save(entry: String, forKey key: String) throws {
+        guard !entry.isEmpty && !key.isEmpty else {
+            print("Can't add an empty string to the keychain")
+            throw SecureStoreError.invalidContent
+        }
+        // remove old value if any
+//        try delete(forKey: key)
+        
+        var queryDictionary = try setupQueryDictionary(forKey: key)
+        
+        // add the value
+        queryDictionary[kSecValueData] = entry.data(using: .utf8)
+        
+        let status = SecItemAdd(queryDictionary as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SecureStoreError.failure(error: status.error)
+        }
+    }
+    
+    func retrieve(forKey key: String) throws -> String? {
+        guard !key.isEmpty else {
+            throw SecureStoreError.invalidContent
+        }
+        
+        var queryDictionary = try setupQueryDictionary(forKey: key)
+        // Set additional query attributes
+        queryDictionary[kSecReturnData] = kCFBooleanTrue // expecting result of type Data
+        queryDictionary[kSecMatchLimit] = kSecMatchLimitOne // limit the number of search results to one
+        
+        var data: AnyObject?
+        
+        // Returns one or more keychain items that match a search query, or copies attributes of specific keychain items
+        let status = SecItemCopyMatching(queryDictionary as CFDictionary, &data) // search query
+        guard status == errSecSuccess else {
+            throw SecureStoreError.failure(error: status.error)
+        }
+        
+        guard let itemData = data as? Data,
+            let result = String(data: itemData, encoding: .utf8) else {
+            return nil
+        }
+        
+        return result
+    }
+    
+    func delete(forKey key: String) throws {
+        guard !key.isEmpty else {
+            print("Key must be valid")
+            throw SecureStoreError.invalidContent
+        }
+        
+        let queryDictionary = try setupQueryDictionary(forKey: key)
+        
+        let status = SecItemDelete(queryDictionary as CFDictionary)
+        guard status == errSecSuccess else {
+            throw SecureStoreError.failure(error: status.error)
+        }
+    }
+}

--- a/EZ Recipes/EZ Recipes/Helpers/OSStatusExtension.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/OSStatusExtension.swift
@@ -1,0 +1,23 @@
+//
+//  OSStatusExtension.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 12/13/24.
+//
+
+import Foundation
+
+extension OSStatus {
+    /// Convert an OSStatus code to a more human-readable error
+    /// - Returns: an `NSError` object with the error message, or `nil` if the status is success
+    /// - Note: OSStatus codes can be found at https://www.osstatus.com/
+    var error: NSError {
+//        guard self != errSecSuccess else { return nil }
+
+        let message = SecCopyErrorMessageString(self, nil) as String? ?? "Unknown error"
+
+        return NSError(domain: NSOSStatusErrorDomain, code: Int(self), userInfo: [
+            NSLocalizedDescriptionKey: message
+        ])
+    }
+}

--- a/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/UserDefaultsManager.swift
@@ -10,8 +10,8 @@ import OSLog
 
 /// Helper methods for UserDefaults
 ///
-/// - Note: UserDefaults stored at ~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Preferences
-/// (/var/mobile/Containers/... on real devices) (~/Library/Developer/Xcode/UserData/Previews/Simulator Devices/... in previews) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`) (view plist file by running `/usr/libexec/PlistBuddy -c print PLIST-FILE`)
+/// - Note: UserDefaults stored at `~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Containers/Data/Application/_App-UUID_/Library/Preferences`
+/// (`/var/mobile/Containers/...` on real devices) (`~/Library/Developer/Xcode/UserData/Previews/Simulator Devices/...` in previews) (Device-UUID and App-UUID gotten from `xcrun simctl get_app_container booted BUNDLE-ID data`) (view plist file by running `/usr/libexec/PlistBuddy -c print PLIST-FILE`)
 struct UserDefaultsManager {
     private static let userDefaults = UserDefaults.standard
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "UserDefaultsManager")

--- a/EZ Recipes/EZ RecipesTests/Helpers/KeychainManagerTests.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/KeychainManagerTests.swift
@@ -1,0 +1,23 @@
+//
+//  KeychainManagerTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 12/13/24.
+//
+
+import XCTest
+@testable import EZ_Recipes
+
+final class KeychainManagerTests: XCTestCase {
+    let keychain = KeychainManager.shared
+    let key = "token"
+    let token = "mockJwt"
+    
+    func testSaveToken() throws {
+        XCTAssertThrowsError(try keychain.retrieve(forKey: key))
+        try keychain.save(entry: token, forKey: key)
+        XCTAssertEqual(try keychain.retrieve(forKey: key), token)
+        try keychain.delete(forKey: key)
+        XCTAssertThrowsError(try keychain.retrieve(forKey: key))
+    }
+}


### PR DESCRIPTION
This is very early on, but I couldn't resist learning about the Keychain! Let's spill the beans about how it works:
- Unlike the Keystore, the Keychain can store items. In fact, like Core Data, it's just a SQLite database under the hood.
- The Keychain is stored globally on the device instead of in the app's directory. Access to each item is controlled on a per-app basis.
- Most items are encrypted if viewed normally. But with the right private key, each app can decrypt the items they own.
- If an app is uninstalled, the Keychain items aren't deleted. They can be recovered if the app is reinstalled or be purged by other external factors.
- The login keychain is owned by the user, while the system keychain is owned by the root user.
- There are 5 different security classes: **Key**, **Identity**, **Certificate**, **Generic Password**, & **Internet Password**.
  - Under the Passwords tab, generic passwords have a pencil icon, while internet passwords have an @ icon. For storing JWTs, we'll stick with the generic password class.
  - Keys and certificates are in separate tabs. Since identities are key-cert pairs, I assume they can belong in either category?
  - Items are stored in different SQLite tables depending on the class: (Key = `keys`, Identity = keys/cert?, Certificate = `cert`, Generic Password = `genp`, Internet Password = `inet`)
- Generic passwords (aka application passwords in the Keychain UI) are uniquely identified by their account and service attributes (see https://developer.apple.com/documentation/security/errsecduplicateitem). In the UI, the name field maps to the service attribute. For our code (and most code I see online), we'll use the account attribute as the key for each item we store.
- The where field corresponds to the `kSecAttrServer` attribute (at least according to ChatGPT :P).
- Comments can optionally be added to explain a Keychain item.
- The actual value is stored encrypted in `kSecValueData`. To decrypt it, a password may be required. On iOS, you may need to use biometrics instead. I enabled this flag for better security, but we'll see how much this impacts the UX.
- `kSecAttrAccessible` and/or `kSecAttrAccessControl` control whether a passcode is required to decrypt a Keychain item.
- By default, Keychain items are only accessible by the app that created the item. To share items across multiple apps, you need to specify `kSecAttrAccessGroup`. The apps need to share the same team ID (signed by the same provisioning profile). The access group is prioritized as follows:
  - `keychain-access-group` strings requiring the Keychain Sharing capability
  - The app ID (team ID + bundle ID) (default if not specified)
  - `com.apple.security.application-groups` strings requiring the App Groups capability (the same IPC method to share UserDefaults between apps)
- Access groups correspond to the `agrp` column in the `genp` table, which happens to be one of the only plaintext portions of the table. So that can be used to determine if a JWT is stored in the EZ Recipes app.
- [This guy](https://gist.github.com/0xmachos/5bcf2ad0085e09f3b553a88bb0e0574d) has some good documentation on each column in the table.