### PR TITLE
69 searchsequencetoken not escaped properly

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
-        "version" : "5.9.1"
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
       }
     },
     {

--- a/EZ Recipes/EZ Recipes/Helpers/AFLogger.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/AFLogger.swift
@@ -9,7 +9,7 @@ import Alamofire
 import OSLog
 
 // Logs the network requests & responses
-class AFLogger: EventMonitor {
+final class AFLogger: EventMonitor {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "AFLogger")
     
     func requestDidResume(_ request: Request) {

--- a/EZ Recipes/EZ Recipes/Helpers/RecipeFilterEncoder.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/RecipeFilterEncoder.swift
@@ -55,7 +55,17 @@ private struct CustomBoolEncoder: ParameterEncoder {
         }
         
         var urlComponents = URLComponents(string: urlString)
-        urlComponents?.queryItems = queryItems
+        // Escape +'s if they appear in tokens
+        let queryString = queryItems
+            .map {
+                return if let value = $0.value {
+                    "\($0.name)=\(value.addingPercentEncoding(withAllowedCharacters: .afURLQueryAllowed) ?? "")"
+                } else {
+                    "\($0.name)"
+                }
+            }
+            .joined(separator: "&")
+        urlComponents?.percentEncodedQuery = queryString
         request.url = urlComponents?.url
         
         return request

--- a/EZ Recipes/EZ RecipesTests/Helpers/RecipeFilterEncoderTests.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/RecipeFilterEncoderTests.swift
@@ -117,6 +117,17 @@ final class RecipeFilterEncoderTests: XCTestCase {
         let encodedRequest = try encoder.encode(parameters, into: urlRequest)
         
         // Then all the values should appear in the query parameters
-        assertEquals(encodedRequest.url?.query(), "query=salad&min-cals=0&max-cals=2000&vegetarian&vegan&gluten-free&healthy&cheap&sustainable&spice-level=none&spice-level=mild&spice-level=spicy&type=hor%20d\'oeuvre&culture=Eastern%20European&culture=Middle%20Eastern")
+        assertEquals(encodedRequest.url?.query(), "query=salad&min-cals=0&max-cals=2000&vegetarian&vegan&gluten-free&healthy&cheap&sustainable&spice-level=none&spice-level=mild&spice-level=spicy&type=hor%20d%27oeuvre&culture=Eastern%20European&culture=Middle%20Eastern")
+    }
+    
+    func testEncodeSpecialCharacters() throws {
+        // Give a recipe filter with special characters
+        let parameters = RecipeFilter(query: "pizza with :#[]@", token: "!$&'()*+,;=")
+        
+        // When encoded
+        let encodedRequest = try encoder.encode(parameters, into: urlRequest)
+        
+        // Then all the characters should be URL-encoded
+        assertEquals(encodedRequest.url?.query(), "query=pizza%20with%20%3A%23%5B%5D%40&token=%21%24%26%27%28%29%2A%2B%2C%3B%3D")
     }
 }


### PR DESCRIPTION
> Request: GET https://ez-recipes-server.onrender.com/api/recipes?healthy&query=squash&token=CL0IFbw%2BFEAiDloMZsj8CEKMOJlcA7Ye&type=main%20course
Response: success([])

The token is now getting escaped properly. In fact, it should be able to escape all the characters in the linked issue.