### PR TITLE
Skip screenshots in the pipeline to avoid timeouts

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		5E5AD98C2D7CD1B8001D415C /* .github */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); name = .github; path = ../.github; sourceTree = "<group>"; };
 		5E5AD9B62D7CD24B001D415C /* screenshots */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); name = screenshots; path = ../screenshots; sourceTree = "<group>"; };
-		5E5AD9CB2D7CD295001D415C /* fastlane */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5E5ADA942D7CD62A001D415C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = fastlane; sourceTree = "<group>"; };
+		5E5AD9CB2D7CD295001D415C /* fastlane */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5E5ADA942D7CD62A001D415C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {Appfile = text.script.ruby; Fastfile = text.script.ruby; Matchfile = text.script.ruby; Pluginfile = text.script.ruby; Snapfile = text.script.ruby; }; explicitFolders = (); path = fastlane; sourceTree = "<group>"; };
 		5E5AD9CD2D7CD366001D415C /* EZ RecipesUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "EZ RecipesUITests"; sourceTree = "<group>"; };
 		5E5AD9E12D7CD36B001D415C /* EZ RecipesTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "EZ RecipesTests"; sourceTree = "<group>"; };
 		5E5ADA482D7CD3B1001D415C /* EZ Recipes */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5E5ADA922D7CD3B1001D415C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "EZ Recipes"; sourceTree = "<group>"; };
@@ -437,6 +437,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EZ-Recipes-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -464,6 +465,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EZ-Recipes-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -9,7 +9,8 @@ import XCTest
 
 @MainActor
 class EZ_RecipesUITests: XCTestCase {
-    var app: XCUIApplication!
+    private var app: XCUIApplication!
+    private let isLocal = ProcessInfo.processInfo.environment["CI"] != "true"
 
     // Snapshot methods must be called on the main thread, but XCTestCase doesn't require isolation
     override func setUp() async throws {
@@ -21,7 +22,10 @@ class EZ_RecipesUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
         app = XCUIApplication()
         app.launchArguments.append("isUITest")
-        setupSnapshot(app)
+        if isLocal {
+            // Screenshots can time out on GitHub Actions
+            setupSnapshot(app)
+        }
         app.launch()
     }
 
@@ -39,12 +43,23 @@ class EZ_RecipesUITests: XCTestCase {
             app.buttons[tab].tap()
         }
     }
+    
+    private func takeScreenshot(withName name: String, shotNum: Int? = nil) {
+        if isLocal {
+            var screenshotName = name
+            if let shotNum {
+                screenshotName += "-\(shotNum)"
+            }
+            snapshot(screenshotName)
+        }
+    }
 
     func testFindMeARecipe() throws {
         // Tap the "Find Me A Recipe!" button and check that the recipe page loads properly (this will consume quota)
         // Take screenshots along the way
+        var screenshotName = "home-view"
         var shotNum = 1
-        snapshot("home-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // If the sidebar button exists, check that the select recipe text is shown and tapping the sidebar button opens the home view
@@ -55,7 +70,7 @@ class EZ_RecipesUITests: XCTestCase {
             XCTAssert(selectRecipe.exists, "Error line \(#line): The secondary view text isn't showing")
             
             sidebarButton.tap()
-            snapshot("home-view-\(shotNum)")
+            takeScreenshot(withName: screenshotName, shotNum: shotNum)
             shotNum += 1
         }
         
@@ -82,8 +97,9 @@ class EZ_RecipesUITests: XCTestCase {
         if popoverDismissRegion.exists {
             popoverDismissRegion.tap()
         }
+        screenshotName = "recipe-view"
         shotNum = 1
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // Check that the favorite button toggles between filling and un-filling when tapped
@@ -115,7 +131,7 @@ class EZ_RecipesUITests: XCTestCase {
         // Scroll down and take screenshots of the recipe view
         let scrollView = app.scrollViews.firstMatch
         scrollView.swipeUp() // swipe up will scroll the whole screen
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // Check that the nutrition label contains all the required nutritional properties (except fiber)
@@ -125,26 +141,26 @@ class EZ_RecipesUITests: XCTestCase {
         }
         
         scrollView.swipeUp()
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // Check that the summary box, ingredients list, instructions list, and footer are present
         let summary = app.staticTexts["Summary"]
         XCTAssert(summary.exists, "Error line \(#line): The summary box is missing")
         scrollView.swipeUp()
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         let ingredients = app.staticTexts["Ingredients"]
         XCTAssert(ingredients.exists, "Error line \(#line): The ingredients list is missing")
         scrollView.swipeUp()
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         let steps = app.staticTexts["Steps"]
         XCTAssert(steps.exists, "Error line \(#line): The instructions list is missing")
         scrollView.swipeUp()
-        snapshot("recipe-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         let attribution = app.staticTexts["Powered by spoonacular"]
@@ -158,8 +174,9 @@ class EZ_RecipesUITests: XCTestCase {
     func testSearchRecipes() throws {
         // Go to the Search tab
         goTo(tab: "Search")
+        let screenshotName = "search-view"
         var shotNum = 1
-        snapshot("search-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // If the sidebar button exists, check that the search recipes text is shown and tapping the sidebar button opens the filter form
@@ -170,7 +187,7 @@ class EZ_RecipesUITests: XCTestCase {
             XCTAssert(searchRecipes.exists, "Error line \(#line): The secondary view text isn't showing")
             
             sidebarButton.tap()
-            snapshot("search-view-\(shotNum)")
+            takeScreenshot(withName: screenshotName, shotNum: shotNum)
             shotNum += 1
         }
         
@@ -337,7 +354,7 @@ class EZ_RecipesUITests: XCTestCase {
         
         let cuisines = collectionViewsQuery.staticTexts["Italian"]
         XCTAssert(cuisines.exists, "Error line \(#line): The cuisines selected aren't shown")
-        snapshot("search-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
         
         // Submit the form and wait for results
@@ -348,13 +365,13 @@ class EZ_RecipesUITests: XCTestCase {
         if popoverDismissRegion.exists {
             popoverDismissRegion.tap()
         }
-        snapshot("search-view-\(shotNum)")
+        takeScreenshot(withName: screenshotName, shotNum: shotNum)
         shotNum += 1
     }
     
     func testGlossaryScreen() throws {
         // Take a screenshot of the glossary tab (no assertions)
         goTo(tab: "Glossary")
-        snapshot("glossary-view")
+        takeScreenshot(withName: "glossary-view")
     }
 }

--- a/EZ Recipes/EZ-Recipes-Info.plist
+++ b/EZ Recipes/EZ-Recipes-Info.plist
@@ -2,13 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict/>
-	</dict>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIImageName</key>

--- a/EZ Recipes/fastlane/Fastfile
+++ b/EZ Recipes/fastlane/Fastfile
@@ -36,14 +36,16 @@ platform :ios do
     # Resolve package dependencies: xcodebuild -resolvePackageDependencies -scheme EZ\ Recipes -project ./EZ\ Recipes.xcodeproj -disableAutomaticPackageResolution
     # Show build settings: xcodebuild -showBuildSettings -scheme EZ\ Recipes -project ./EZ\ Recipes.xcodeproj -disableAutomaticPackageResolution
     # Disable 'Slide to Type' on each simulator: /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" ~/Library/Developer/CoreSimulator/Devices/84CA0B87-356F-4160-A3E7-5AC636BEF880/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1
-    # Clean, build project, & run unit and UI tests on all simulators: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme EZ\ Recipes -project ./EZ\ Recipes.xcodeproj -derivedDataPath ~/Library/Developer/Xcode/DerivedData/EZ_Recipes-cuhmoxzpybdazjcsljkgfvxmyeud -destination 'platform=iOS Simulator,id=ACCE5FA5-142E-4DDB-89D5-18BD949644EC' -destination 'platform=iOS Simulator,id=AD55AFA8-4014-406B-996D-58BD6548F72A' -destination 'platform=iOS Simulator,id=DDD5015F-9C9F-434F-9454-3748C749A432' clean build test | tee '~/Library/Logs/scan/EZ Recipes-EZ Recipes.log' | xcbeautify --renderer github-actions
+    # Clean, build project, & run unit and UI tests on all simulators: set -o pipefail && env NSUnbufferedIO=YES TEST_RUNNER_CI=true xcodebuild -scheme EZ\ Recipes -project ./EZ\ Recipes.xcodeproj -derivedDataPath ~/Library/Developer/Xcode/DerivedData/EZ_Recipes-cuhmoxzpybdazjcsljkgfvxmyeud -destination 'platform=iOS Simulator,id=ACCE5FA5-142E-4DDB-89D5-18BD949644EC' -destination 'platform=iOS Simulator,id=AD55AFA8-4014-406B-996D-58BD6548F72A' -destination 'platform=iOS Simulator,id=DDD5015F-9C9F-434F-9454-3748C749A432' clean build test | tee '~/Library/Logs/scan/EZ Recipes-EZ Recipes.log' | xcbeautify --renderer github-actions
     run_tests(scheme: APP_SCHEME,
               device: options[:device],
               #skip_testing: ["EZ RecipesUITests"], # in case GitHub Actions is acting naughty (TestTarget[/TestClass[/TestMethod]])
               clean: true,
               xcodebuild_formatter: "xcbeautify --renderer github-actions",
               output_types: "junit",
-              disable_package_automatic_updates: true)
+              disable_package_automatic_updates: true,
+              # TEST_RUNNER_ stripped from env var, must appear before xcodebuild
+              xcodebuild_command: "env NSUnbufferedIO=YES TEST_RUNNER_CI=#{ENV['GITHUB_ACTIONS']} xcodebuild")
   end
   
   desc "Generate screenshots for the App Store"


### PR DESCRIPTION
Like Android, we don't have to take screenshots in the pipeline. And lately, we've been getting occasional timeouts when taking screenshots:
> ::error file=/Users/runner/work/ez-recipes-ios/ez-recipes-ios/EZ Recipes/fastlane/SnapshotHelper.swift,line=170::    testFindMeARecipe, Failed to get screenshot: Timed out while requesting screenshot.

I found a (frankly hidden) way to pass environment variables to UI tests by passing `TEST_RUNNER_*` before `xcodebuild`. Since we can pick up environment variables from Fastlane, I referenced the `GITHUB_ACTIONS` variable to check if we're running in the pipeline. This translates to looking up `ProcessInfo` in the Swift file. The only references I found to this feature were from [this SO post](https://stackoverflow.com/a/69237460), the [Xcode 13 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes), and the `xcodebuild` man page. Apple also references this in [these docs](https://developer.apple.com/documentation/xcode/environment-variable-reference) and [this video](https://www.youtube.com/watch?v=_CvZQ5ze4h4), but only in the context of Xcode Cloud. Silly Apple, this is baked into the Xcode CLI. We don't need a subscription to access this feature!

...Now if the builds still fail, hopefully it's not the same error above so I don't jinx myself. 😊