### PR TITLE
Profile Pt 3: ProfileViewModel

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5E0405A72DA0CFF300C3B312 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 5E0405A62DA0CFF300C3B312 /* AlertToast */; };
 		F12C1C662904D16700C3302B /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = F12C1C652904D16700C3302B /* Alamofire */; };
 		F17A80A52B78764300E811C8 /* MultiPicker in Frameworks */ = {isa = PBXBuildFile; productRef = F17A80A42B78764300E811C8 /* MultiPicker */; };
 /* End PBXBuildFile section */
@@ -71,6 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E0405A72DA0CFF300C3B312 /* AlertToast in Frameworks */,
 				F17A80A52B78764300E811C8 /* MultiPicker in Frameworks */,
 				F12C1C662904D16700C3302B /* Alamofire in Frameworks */,
 			);
@@ -144,6 +146,7 @@
 			packageProductDependencies = (
 				F12C1C652904D16700C3302B /* Alamofire */,
 				F17A80A42B78764300E811C8 /* MultiPicker */,
+				5E0405A62DA0CFF300C3B312 /* AlertToast */,
 			);
 			productName = "EZ Recipes";
 			productReference = F12C1C272904951600C3302B /* EZ Recipes.app */;
@@ -226,6 +229,7 @@
 			packageReferences = (
 				F12C1C642904D16600C3302B /* XCRemoteSwiftPackageReference "Alamofire" */,
 				F17A80A32B78764300E811C8 /* XCRemoteSwiftPackageReference "MultiPicker" */,
+				5E0405A52DA0CFF300C3B312 /* XCRemoteSwiftPackageReference "AlertToast" */,
 			);
 			productRefGroup = F12C1C282904951600C3302B /* Products */;
 			projectDirPath = "";
@@ -586,6 +590,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5E0405A52DA0CFF300C3B312 /* XCRemoteSwiftPackageReference "AlertToast" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/elai950/AlertToast.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.9;
+			};
+		};
 		F12C1C642904D16600C3302B /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -605,6 +617,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5E0405A62DA0CFF300C3B312 /* AlertToast */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E0405A52DA0CFF300C3B312 /* XCRemoteSwiftPackageReference "AlertToast" */;
+			productName = AlertToast;
+		};
 		F12C1C652904D16700C3302B /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F12C1C642904D16600C3302B /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					F12C1C262904951600C3302B = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -335,6 +335,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = UF6E5BVT98;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -400,6 +401,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = UF6E5BVT98;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -432,11 +434,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EZ Recipes/Preview Content\"";
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EZ-Recipes-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "Securely manage your account";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -460,11 +462,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EZ Recipes/Preview Content\"";
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EZ-Recipes-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "Securely manage your account";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -486,7 +488,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-RecipesTests";
@@ -503,7 +504,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-RecipesTests";
@@ -519,7 +519,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-RecipesUITests";
@@ -535,7 +534,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UF6E5BVT98;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-RecipesUITests";

--- a/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2e87e198b2363d2f23b729e1c8a890728c419450ba9d690c5c45f32db5b7f2e5",
+  "originHash" : "6a68cba788122d8f0baec7843d952ad365f75f7b7680aaff63834b9146aaa733",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
         "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "alerttoast",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/elai950/AlertToast.git",
+      "state" : {
+        "revision" : "b39252eacd159904afd7d718bba0afabb87f2f2f",
+        "version" : "1.3.9"
       }
     },
     {

--- a/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ Recipes.xcscheme
+++ b/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ Recipes.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ RecipesUITests.xcscheme
+++ b/EZ Recipes/EZ Recipes.xcodeproj/xcshareddata/xcschemes/EZ RecipesUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -17,6 +17,7 @@ struct Constants {
     static let appName = "EZ Recipes"
     static let errorTitle = String(localized: "Error")
     static let unknownError = String(localized: "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-ios/issues")
+    static let noTokenFound = String(localized: "No token found")
     static let okButton = String(localized: "OK")
     static let loadingMessages = [
         "Prepping the ingredients... 🍱",

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -336,8 +336,8 @@ struct Constants {
         """))}
         
         static let changeEmailField = String(localized: "New Email")
-        static let changeEmailConfirm: @Sendable (String) -> String = { email in
-            String(localized: "We sent an email to \(email). Follow the instructions to change your email.")
+        static let changeEmailConfirm: @Sendable (String) -> LocalizedStringKey = { email in
+            LocalizedStringKey(String(localized: "We sent an email to **\(email)**. Follow the instructions to change your email."))
         }
         static let changeEmailSuccess = String(localized: "Email updated successfully! Please sign in again.")
         static let changePasswordField = String(localized: "New Password")
@@ -345,6 +345,7 @@ struct Constants {
         static let deleteAccountHeader = String(localized: "Are You Sure?")
         static let deleteAccountSubHeader = String(localized: """
         You will lose access to your favorite recipes.
+        
         Enter your username to confirm.
         """)
         static let deleteAccountSuccess = String(localized: "Your account has been deleted.")

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -342,6 +342,8 @@ struct Constants {
         static let changeEmailSuccess = String(localized: "Email updated successfully! Please sign in again.")
         static let changePasswordField = String(localized: "New Password")
         static let changePasswordSuccess = String(localized: "Password updated successfully! Please sign in again.")
+        static let changePasswordSuccessHeader = String(localized: "Password updated successfully!")
+        static let changePasswordSuccessSubHeader = String(localized: "Please sign in again.")
         static let deleteAccountHeader = String(localized: "Are You Sure?")
         static let deleteAccountSubHeader = String(localized: """
         You will lose access to your favorite recipes.

--- a/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
@@ -33,6 +33,7 @@ struct KeychainManager {
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "KeychainManager")
     enum Key: String {
         case token
+        case mockToken // for tests only
     }
     
     private static func setupQueryDictionary(forKey key: Key) throws -> [CFString: Any] {

--- a/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
@@ -42,23 +42,25 @@ struct KeychainManager {
             throw SecureStoreError.invalidContent
         }
         
-        var error: Unmanaged<CFError>?
-        guard let accessControl = SecAccessControlCreateWithFlags(
-            kCFAllocatorDefault,
-            // Make the Keychain accessible only if the device has a passcode and is unlocked
-            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-            // Require biometrics or a passcode to access
-            .userPresence,
-            &error
-        ) else {
-            logger.error("Could not create access control flags :: Error: \(String(describing: error))")
-            throw SecureStoreError.invalidContent
-        }
+        // Skipping biometrics since they're not needed for every token operation
+//        var error: Unmanaged<CFError>?
+//        guard let accessControl = SecAccessControlCreateWithFlags(
+//            kCFAllocatorDefault,
+//            // Make the Keychain accessible only if the device has a passcode and is unlocked
+//            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+//            // Require biometrics or a passcode to access
+//            .userPresence,
+//            &error
+//        ) else {
+//            logger.error("Could not create access control flags :: Error: \(String(describing: error))")
+//            throw SecureStoreError.invalidContent
+//        }
         
         return [
             kSecClass: kSecClassGenericPassword, // genp table
             kSecAttrAccount: keyData, // account == key
-            kSecAttrAccessControl: accessControl
+            kSecAttrAccessible: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+//            kSecAttrAccessControl: accessControl
         ]
     }
     

--- a/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/KeychainManager.swift
@@ -14,6 +14,17 @@ enum SecureStoreError: Error {
     case failure(error: NSError)
 }
 
+extension SecureStoreError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidContent:
+            return "The data provided is invalid."
+        case .failure(let error):
+            return error.localizedDescription // converts Error.localizedDescription to NSError.localizedDescription
+        }
+    }
+}
+
 /// Helper methods for the Keychain
 ///
 /// - Note: Keychain stored at `~/Library/Developer/CoreSimulator/Devices/_Device-UUID_/data/Library/Keychains`

--- a/EZ Recipes/EZ Recipes/InfoPlist.xcstrings
+++ b/EZ Recipes/EZ Recipes/InfoPlist.xcstrings
@@ -12,6 +12,18 @@
           }
         }
       }
+    },
+    "NSFaceIDUsageDescription" : {
+      "comment" : "Privacy - Face ID Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Securely manage your account"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/EZ Recipes/EZ Recipes/Localizable.xcstrings
+++ b/EZ Recipes/EZ Recipes/Localizable.xcstrings
@@ -316,6 +316,9 @@
     "Healthy" : {
 
     },
+    "Hello, World!" : {
+
+    },
     "Hide password" : {
 
     },

--- a/EZ Recipes/EZ Recipes/Localizable.xcstrings
+++ b/EZ Recipes/EZ Recipes/Localizable.xcstrings
@@ -388,7 +388,13 @@
     "Password must be at least 8 characters long" : {
 
     },
+    "Password updated successfully!" : {
+
+    },
     "Password updated successfully! Please sign in again." : {
+
+    },
+    "Please sign in again." : {
 
     },
     "Powered by spoonacular" : {

--- a/EZ Recipes/EZ Recipes/Localizable.xcstrings
+++ b/EZ Recipes/EZ Recipes/Localizable.xcstrings
@@ -316,9 +316,6 @@
     "Healthy" : {
 
     },
-    "Hello, World!" : {
-
-    },
     "Hide password" : {
 
     },
@@ -539,16 +536,16 @@
     "We just need to verify your email before you can put on the chef's hat.\nCheck your email for a magic link sent to **%@**\n\n⚠️ We will delete accounts from our system if they're not verified within 1 week." : {
 
     },
-    "We sent an email to **%@**. Follow the instructions to reset your password.\n\nIf you didn't receive an email, you may not have created an account with this email." : {
+    "We sent an email to **%@**. Follow the instructions to change your email." : {
 
     },
-    "We sent an email to %@. Follow the instructions to change your email." : {
+    "We sent an email to **%@**. Follow the instructions to reset your password.\n\nIf you didn't receive an email, you may not have created an account with this email." : {
 
     },
     "You must be signed in to rate this recipe" : {
 
     },
-    "You will lose access to your favorite recipes.\nEnter your username to confirm." : {
+    "You will lose access to your favorite recipes.\n\nEnter your username to confirm." : {
 
     },
     "You're Almost There!" : {

--- a/EZ Recipes/EZ Recipes/Localizable.xcstrings
+++ b/EZ Recipes/EZ Recipes/Localizable.xcstrings
@@ -370,6 +370,9 @@
     "No recipes found" : {
 
     },
+    "No token found" : {
+
+    },
     "Nutrition Facts" : {
 
     },

--- a/EZ Recipes/EZ Recipes/Models/Profile/Chef.swift
+++ b/EZ Recipes/EZ Recipes/Models/Profile/Chef.swift
@@ -5,7 +5,7 @@
 //  Created by Abhishek Chaudhuri on 2/17/25.
 //
 
-struct Chef: Codable {
+struct Chef: Codable, Equatable {
     let uid: String
     let email: String
     let emailVerified: Bool
@@ -13,4 +13,8 @@ struct Chef: Codable {
     let recentRecipes: [String: String]
     let favoriteRecipes: [String]
     let token: String
+    
+    func copy(emailVerified: Bool) -> Self {
+        return Chef(uid: self.uid, email: self.email, emailVerified: emailVerified, ratings: self.ratings, recentRecipes: self.recentRecipes, favoriteRecipes: self.favoriteRecipes, token: self.token)
+    }
 }

--- a/EZ Recipes/EZ Recipes/Models/Profile/ChefUpdate.swift
+++ b/EZ Recipes/EZ Recipes/Models/Profile/ChefUpdate.swift
@@ -8,5 +8,5 @@
 struct ChefUpdate: Encodable {
     let type: ChefUpdateType
     let email: String
-    let password: String?
+    var password: String? = nil
 }

--- a/EZ Recipes/EZ Recipes/Models/Profile/LoginResponse.swift
+++ b/EZ Recipes/EZ Recipes/Models/Profile/LoginResponse.swift
@@ -9,4 +9,8 @@ struct LoginResponse: Decodable {
     let uid: String
     let token: String
     let emailVerified: Bool
+    
+    func copy(emailVerified: Bool) -> Self {
+        return LoginResponse(uid: self.uid, token: self.token, emailVerified: emailVerified)
+    }
 }

--- a/EZ Recipes/EZ Recipes/Services/AFLogger.swift
+++ b/EZ Recipes/EZ Recipes/Services/AFLogger.swift
@@ -65,13 +65,17 @@ final class AFLogger: EventMonitor {
     
     func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
         // Headers are already logged here
-        logger.debug("[AF Response] Metrics: \(response.metrics)")
+        // logger.debug("[AF Response] Metrics: \(response.metrics)")
         
         let urlResponse = response.response
         let method = response.request?.httpMethod
         let url = urlResponse?.url?.absoluteString
         let status = urlResponse?.statusCode
         var log = "[AF Response] Method: \(method ?? "") | URL: \(url ?? "") | Status: \(status?.description ?? "")"
+        
+        if let headers = urlResponse?.headers.dictionary {
+            log += " | Headers: \(redact(headers))"
+        }
         
         if let bodyData = response.data, let body = String(data: bodyData, encoding: .utf8) {
             log += " | Data: \(redact(body))"

--- a/EZ Recipes/EZ Recipes/Services/AFLogger.swift
+++ b/EZ Recipes/EZ Recipes/Services/AFLogger.swift
@@ -35,7 +35,9 @@ final class AFLogger: EventMonitor {
         for field in fieldsToRedact {
             let oldFieldRegex = Regex {
                 field
-                "\":\"[^\"]+\""
+                "\":\""
+                OneOrMore(CharacterClass.anyOf("\"").inverted) // [^\"]+
+                "\""
             }
             
             redactedBody = redactedBody.replacing(oldFieldRegex, with: "\(field)\":\"\(MASK)\"")

--- a/EZ Recipes/EZ Recipes/Services/ChefRepository.swift
+++ b/EZ Recipes/EZ Recipes/Services/ChefRepository.swift
@@ -16,3 +16,9 @@ protocol ChefRepository: Sendable {
     func login(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError>
     func logout(token: String) async -> Result<Void, RecipeError>
 }
+
+extension ChefRepository {
+    func updateChef(fields: ChefUpdate) async -> Result<ChefEmailResponse, RecipeError> {
+        return await updateChef(fields: fields, token: nil)
+    }
+}

--- a/EZ Recipes/EZ Recipes/Services/ChefRepository.swift
+++ b/EZ Recipes/EZ Recipes/Services/ChefRepository.swift
@@ -5,16 +5,18 @@
 //  Created by Abhishek Chaudhuri on 3/15/25.
 //
 
+import Alamofire
+
 protocol ChefRepository: Sendable {
     static var shared: Self { get }
     
     func getChef(token: String) async -> Result<Chef, RecipeError>
     func createChef(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError>
     func updateChef(fields: ChefUpdate, token: String?) async -> Result<ChefEmailResponse, RecipeError>
-    func deleteChef(token: String) async -> Result<Void, RecipeError> // empty response
+    func deleteChef(token: String) async -> Result<Empty, RecipeError> // empty response
     func verifyEmail(token: String) async -> Result<ChefEmailResponse, RecipeError>
     func login(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError>
-    func logout(token: String) async -> Result<Void, RecipeError>
+    func logout(token: String) async -> Result<Empty, RecipeError>
 }
 
 extension ChefRepository {

--- a/EZ Recipes/EZ Recipes/Services/NetworkManager.swift
+++ b/EZ Recipes/EZ Recipes/Services/NetworkManager.swift
@@ -33,7 +33,8 @@ struct NetworkManager {
                 return .failure(recipeError)
             } catch {
                 // Create a RecipeError object with the raw error response
-                return .failure(RecipeError(error: error.localizedDescription))
+                let errorResponse = try? await request.serializingString().value
+                return .failure(RecipeError(error: errorResponse ?? Constants.unknownError))
             }
         }
     }

--- a/EZ Recipes/EZ Recipes/Services/NetworkManager.swift
+++ b/EZ Recipes/EZ Recipes/Services/NetworkManager.swift
@@ -81,7 +81,7 @@ extension NetworkManager: RecipeRepository {
     }
     
     func updateRecipe(withId id: Int, fields: RecipeUpdate, token: String? = nil) async -> Result<Token, RecipeError> {
-        let request = session.request("\(Constants.baseRecipesPath)/\(id)", method: .patch, parameters: fields) { urlRequest in
+        let request = session.request("\(Constants.baseRecipesPath)/\(id)", method: .patch, parameters: fields, encoder: JSONParameterEncoder.default) { urlRequest in
             if let token {
                 urlRequest.addValue(token, forHTTPHeaderField: "Authorization")
             }
@@ -107,12 +107,12 @@ extension NetworkManager: ChefRepository {
     }
     
     func createChef(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError> {
-        let request = session.request(Constants.baseChefsPath, method: .post, parameters: credentials)
+        let request = session.request(Constants.baseChefsPath, method: .post, parameters: credentials, encoder: JSONParameterEncoder.default)
         return await parseResponse(fromRequest: request, method: #function)
     }
     
     func updateChef(fields: ChefUpdate, token: String? = nil) async -> Result<ChefEmailResponse, RecipeError> {
-        let request = session.request(Constants.baseChefsPath, method: .patch, parameters: fields) { urlRequest in
+        let request = session.request(Constants.baseChefsPath, method: .patch, parameters: fields, encoder: JSONParameterEncoder.default) { urlRequest in
             if let token {
                 urlRequest.addValue(token, forHTTPHeaderField: "Authorization")
             }
@@ -132,7 +132,7 @@ extension NetworkManager: ChefRepository {
     }
     
     func login(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError> {
-        let request = session.request("\(Constants.baseChefsPath)/login", method: .post, parameters: credentials)
+        let request = session.request("\(Constants.baseChefsPath)/login", method: .post, parameters: credentials, encoder: JSONParameterEncoder.default)
         return await parseResponse(fromRequest: request, method: #function)
     }
     

--- a/EZ Recipes/EZ Recipes/Services/NetworkManagerMock.swift
+++ b/EZ Recipes/EZ Recipes/Services/NetworkManagerMock.swift
@@ -5,6 +5,8 @@
 //  Created by Abhishek Chaudhuri on 11/13/22.
 //
 
+import Alamofire
+
 // Mock the network calls to fetch a hardcoded recipe
 struct NetworkManagerMock: RecipeRepository, TermRepository, ChefRepository {
     static let shared = NetworkManagerMock()
@@ -60,9 +62,9 @@ struct NetworkManagerMock: RecipeRepository, TermRepository, ChefRepository {
         return isSuccess ? .success(mockChefEmailResponse) : .failure(Constants.Mocks.tokenError)
     }
     
-    func deleteChef(token: String) async -> Result<Void, RecipeError> {
+    func deleteChef(token: String) async -> Result<Empty, RecipeError> {
         // () == Void
-        return isSuccess ? .success(()) : .failure(Constants.Mocks.tokenError)
+        return isSuccess ? .success(.value) : .failure(Constants.Mocks.tokenError)
     }
     
     func verifyEmail(token: String) async -> Result<ChefEmailResponse, RecipeError> {
@@ -73,7 +75,7 @@ struct NetworkManagerMock: RecipeRepository, TermRepository, ChefRepository {
         return isSuccess ? .success(mockLoginResponse.copy(emailVerified: isEmailVerified)) : .failure(Constants.Mocks.tokenError)
     }
     
-    func logout(token: String) async -> Result<Void, RecipeError> {
-        return isSuccess ? .success(()) : .failure(Constants.Mocks.tokenError)
+    func logout(token: String) async -> Result<Empty, RecipeError> {
+        return isSuccess ? .success(.value) : .failure(Constants.Mocks.tokenError)
     }
 }

--- a/EZ Recipes/EZ Recipes/Services/NetworkManagerMock.swift
+++ b/EZ Recipes/EZ Recipes/Services/NetworkManagerMock.swift
@@ -49,11 +49,11 @@ struct NetworkManagerMock: RecipeRepository, TermRepository, ChefRepository {
     
     // MARK: ChefRepository
     func getChef(token: String) async -> Result<Chef, RecipeError> {
-        return isSuccess ? .success(mockChef) : .failure(Constants.Mocks.tokenError)
+        return isSuccess ? .success(mockChef.copy(emailVerified: isEmailVerified)) : .failure(Constants.Mocks.tokenError)
     }
     
     func createChef(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError> {
-        return isSuccess ? .success(mockLoginResponse) : .failure(Constants.Mocks.tokenError)
+        return isSuccess ? .success(mockLoginResponse.copy(emailVerified: isEmailVerified)) : .failure(Constants.Mocks.tokenError)
     }
     
     func updateChef(fields: ChefUpdate, token: String?) async -> Result<ChefEmailResponse, RecipeError> {
@@ -70,7 +70,7 @@ struct NetworkManagerMock: RecipeRepository, TermRepository, ChefRepository {
     }
     
     func login(credentials: LoginCredentials) async -> Result<LoginResponse, RecipeError> {
-        return isSuccess ? .success(mockLoginResponse) : .failure(Constants.Mocks.tokenError)
+        return isSuccess ? .success(mockLoginResponse.copy(emailVerified: isEmailVerified)) : .failure(Constants.Mocks.tokenError)
     }
     
     func logout(token: String) async -> Result<Void, RecipeError> {

--- a/EZ Recipes/EZ Recipes/Services/RecipeRepository.swift
+++ b/EZ Recipes/EZ Recipes/Services/RecipeRepository.swift
@@ -14,3 +14,10 @@ protocol RecipeRepository: Sendable {
     func getRecipe(byId id: Int) async -> Result<Recipe, RecipeError>
     func updateRecipe(withId id: Int, fields: RecipeUpdate, token: String?) async -> Result<Token, RecipeError>
 }
+
+extension RecipeRepository {
+    // Workaround to set a default value for a protocol method
+    func updateRecipe(withId id: Int, fields: RecipeUpdate) async -> Result<Token, RecipeError> {
+        return await updateRecipe(withId: id, fields: fields, token: nil)
+    }
+}

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -1,0 +1,291 @@
+//
+//  ProfileViewModel.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 3/29/25.
+//
+
+import Foundation
+import OSLog
+
+@MainActor
+@Observable class ProfileViewModel: ViewModel {
+    private(set) var isLoading = false
+    private(set) var authState: AuthState = .loading
+    private(set) var chef: Chef?
+    private(set) var openLoginSheet = false
+    private(set) var emailSent = false
+    private(set) var passwordUpdated = false
+    private(set) var accountDeleted = false
+    
+    private(set) var recipeError: RecipeError?
+    private(set) var showAlert = false
+    
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "ProfileViewModel")
+    private var repository: ChefRepository & RecipeRepository
+    
+    required init(repository: ChefRepository & RecipeRepository) {
+        self.repository = repository
+    }
+    
+    private func saveToken(_ token: String) {
+        do {
+            try KeychainManager.save(entry: token, forKey: .token)
+        } catch {
+            logger.error("Error saving token: \(error.localizedDescription)")
+        }
+    }
+    
+    private func getToken() -> String? {
+        do {
+            let token = try KeychainManager.retrieve(forKey: .token)
+            logger.debug("Retrieved ID token from the Keychain")
+            return token
+        } catch {
+            logger.error("Error getting token: \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    private func clearToken() {
+        do {
+            try KeychainManager.delete(key: .token)
+        } catch {
+            logger.error("Error clearing token: \(error.localizedDescription)")
+        }
+    }
+    
+    func createAccount(username: String, password: String) async {
+        let loginCredentials = LoginCredentials(email: username, password: password)
+        
+        isLoading = true
+        let result = await repository.createChef(credentials: loginCredentials)
+        isLoading = false
+        
+        switch result {
+        case .success(let loginResponse):
+            recipeError = nil
+            showAlert = false
+            
+            saveToken(loginResponse.token)
+            chef = Chef(uid: loginResponse.uid, email: username, emailVerified: loginResponse.emailVerified, ratings: [:], recentRecipes: [:], favoriteRecipes: [], token: loginResponse.token)
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = true
+        }
+    }
+    
+    func sendVerificationEmail() async {
+        isLoading = true
+        let token = getToken()
+        let result: Result<ChefEmailResponse, RecipeError> = if let token {
+            await repository.verifyEmail(token: token)
+        } else {
+            .failure(RecipeError(error: Constants.noTokenFound))
+        }
+        isLoading = false
+        
+        switch result {
+        case .success(let emailResponse):
+            recipeError = nil
+            showAlert = false
+            
+            // Don't update the chef's verified status until they click the deep link
+            if let newToken = emailResponse.token {
+                saveToken(newToken)
+            }
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            // Don't show an alert if the user isn't authenticated
+            showAlert = token != nil
+        }
+    }
+    
+    func resetPassword(email: String) async {
+        let fields = ChefUpdate(type: .password, email: email)
+        isLoading = true
+        let result = await repository.updateChef(fields: fields)
+        isLoading = false
+        
+        switch result {
+        case .success:
+            // The response isn't needed
+            emailSent = true
+            recipeError = nil
+            showAlert = false
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = true
+        }
+    }
+    
+    func getChef() async {
+        isLoading = true
+        let token = getToken()
+        let result: Result<Chef, RecipeError> = if let token {
+            await repository.getChef(token: token)
+        } else {
+            .failure(RecipeError(error: Constants.noTokenFound))
+        }
+        isLoading = false
+        
+        switch result {
+        case .success(let chefResponse):
+            chef = chefResponse
+            recipeError = nil
+            showAlert = false
+            
+            saveToken(chefResponse.token)
+            authState = chefResponse.emailVerified ? .authenticated : .unauthenticated
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = token != nil
+            
+            clearToken()
+            authState = .unauthenticated
+        }
+    }
+    
+    func login(username: String, password: String) async {
+        let loginCredentials = LoginCredentials(email: username, password: password)
+        
+        isLoading = true
+        let loginResult = await repository.login(credentials: loginCredentials)
+        
+        switch loginResult {
+        case .success(let loginResponse):
+            recipeError = nil
+            showAlert = false
+            
+            saveToken(loginResponse.token)
+            chef = Chef(uid: loginResponse.uid, email: username, emailVerified: loginResponse.emailVerified, ratings: [:], recentRecipes: [:], favoriteRecipes: [], token: loginResponse.token)
+            
+            // Fetch the rest of the chef's profile
+            let chefResult = await repository.getChef(token: loginResponse.token)
+            isLoading = false
+            
+            switch chefResult {
+            case .success(let chefResponse):
+                chef = chefResponse
+            case .failure(let recipeError):
+                self.recipeError = recipeError
+                showAlert = true
+            }
+            
+            if loginResponse.emailVerified {
+                authState = .authenticated
+                openLoginSheet = false
+            }
+        case .failure(let recipeError):
+            isLoading = false
+            self.recipeError = recipeError
+            showAlert = true
+        }
+    }
+    
+    func logout() async {
+        isLoading = true
+        let token = getToken()
+        let result: Result<Void, RecipeError> = if let token {
+            await repository.logout(token: token)
+        } else {
+            // Assume the user should be signed out since there's no auth token
+            .success(())
+        }
+        isLoading = false
+        
+        switch result {
+        case .success:
+            recipeError = nil
+            showAlert = false
+            
+            clearToken()
+            chef = nil
+            authState = .unauthenticated
+            openLoginSheet = false
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = true
+        }
+    }
+    
+    func updateEmail(newEmail: String) async {
+        let fields = ChefUpdate(type: .email, email: newEmail)
+        
+        isLoading = true
+        let token = getToken()
+        let result: Result<ChefEmailResponse, RecipeError> = if let token {
+            await repository.updateChef(fields: fields, token: token)
+        } else {
+            .failure(RecipeError(error: Constants.noTokenFound))
+        }
+        isLoading = false
+        
+        switch result {
+        case .success(let updateResponse):
+            emailSent = true
+            recipeError = nil
+            showAlert = false
+            
+            if let newToken = updateResponse.token {
+                saveToken(newToken)
+            }
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = token != nil
+        }
+    }
+    
+    func updatePassword(newPassword: String) async {
+        let fields = ChefUpdate(type: .password, email: chef?.email ?? "", password: newPassword)
+        
+        isLoading = true
+        let token = getToken()
+        let result: Result<ChefEmailResponse, RecipeError> = if let token {
+            await repository.updateChef(fields: fields, token: token)
+        } else {
+            .failure(RecipeError(error: Constants.noTokenFound))
+        }
+        isLoading = false
+        
+        switch result {
+        case .success:
+            // The response isn't needed
+            passwordUpdated = true
+            recipeError = nil
+            showAlert = false
+            
+            // The token will be revoked, so sign out the user
+            clearToken()
+            authState = .unauthenticated
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = token != nil
+        }
+    }
+    
+    func deleteAccount() async {
+        isLoading = true
+        let token = getToken()
+        let result: Result<Void, RecipeError> = if let token {
+            await repository.deleteChef(token: token)
+        } else {
+            .failure(RecipeError(error: Constants.noTokenFound))
+        }
+        isLoading = false
+        
+        switch result {
+        case .success:
+            recipeError = nil
+            showAlert = false
+            
+            clearToken()
+            chef = nil
+            authState = .unauthenticated
+            accountDeleted = true
+        case .failure(let recipeError):
+            self.recipeError = recipeError
+            showAlert = token != nil
+        }
+    }
+}

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OSLog
+import Alamofire
 
 @MainActor
 @Observable class ProfileViewModel: ViewModel {
@@ -186,11 +187,11 @@ import OSLog
     func logout() async {
         isLoading = true
         let token = getToken()
-        let result: Result<Void, RecipeError> = if let token {
+        let result: Result<Empty, RecipeError> = if let token {
             await repository.logout(token: token)
         } else {
             // Assume the user should be signed out since there's no auth token
-            .success(())
+            .success(.value)
         }
         isLoading = false
         
@@ -267,7 +268,7 @@ import OSLog
     func deleteAccount() async {
         isLoading = true
         let token = getToken()
-        let result: Result<Void, RecipeError> = if let token {
+        let result: Result<Empty, RecipeError> = if let token {
             await repository.deleteChef(token: token)
         } else {
             .failure(RecipeError(error: Constants.noTokenFound))

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -32,7 +32,7 @@ import OSLog
         do {
             try KeychainManager.save(entry: token, forKey: .token)
         } catch {
-            logger.error("Error saving token: \(error.localizedDescription)")
+            logger.error("Error saving token: \(error)")
         }
     }
     
@@ -42,7 +42,7 @@ import OSLog
             logger.debug("Retrieved ID token from the Keychain")
             return token
         } catch {
-            logger.error("Error getting token: \(error.localizedDescription)")
+            logger.error("Error getting token: \(error)")
             return nil
         }
     }
@@ -51,7 +51,7 @@ import OSLog
         do {
             try KeychainManager.delete(key: .token)
         } catch {
-            logger.error("Error clearing token: \(error.localizedDescription)")
+            logger.error("Error clearing token: \(error)")
         }
     }
     

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -14,7 +14,7 @@ import OSLog
     var authState: AuthState = .loading
     var chef: Chef?
     var openLoginSheet = false
-    private(set) var emailSent = false
+    var emailSent = false
     var passwordUpdated = false
     var accountDeleted = false
     

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -10,16 +10,16 @@ import OSLog
 
 @MainActor
 @Observable class ProfileViewModel: ViewModel {
-    private(set) var isLoading = false
-    private(set) var authState: AuthState = .loading
-    private(set) var chef: Chef?
-    private(set) var openLoginSheet = false
+    var isLoading = false
+    var authState: AuthState = .loading
+    var chef: Chef?
+    var openLoginSheet = false
     private(set) var emailSent = false
-    private(set) var passwordUpdated = false
-    private(set) var accountDeleted = false
+    var passwordUpdated = false
+    var accountDeleted = false
     
     private(set) var recipeError: RecipeError?
-    private(set) var showAlert = false
+    var showAlert = false
     
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? Constants.appName, category: "ProfileViewModel")
     private var repository: ChefRepository & RecipeRepository

--- a/EZ Recipes/EZ Recipes/Views/ContentView.swift
+++ b/EZ Recipes/EZ Recipes/Views/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
                 .tabItem {
                     Constants.Tabs.glossary
                 }
-            ProfileView()
+            ProfileView(viewModel: ProfileViewModel(repository: NetworkManager.shared))
                 .tabItem {
                     Constants.Tabs.profile
                 }

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -64,12 +64,8 @@ struct HomeView: View {
                     // Prevent users from spamming the button
                     .disabled(viewModel.isLoading)
                     // Show an alert if the request failed
-                    .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
-                        Button(Constants.okButton, role: .cancel) {}
-                    } message: {
-                        // recipeError shouldn't be nil if recipeFailedToLoad is true
-                        Text(viewModel.recipeError?.error ?? Constants.unknownError)
-                    }
+                    // recipeError shouldn't be nil if recipeFailedToLoad is true
+                    .errorAlert(isPresented: $viewModel.recipeFailedToLoad, message: viewModel.recipeError?.error)
                     
                     // Show a spinner while the network request is loading
                     // Use opacity instead of an if statement so the button doesn't jump when pressed

--- a/EZ Recipes/EZ Recipes/Views/Login/ForgotPasswordForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/ForgotPasswordForm.swift
@@ -18,8 +18,6 @@ struct ForgotPasswordForm: View {
     @State private var emailInvalid = true
     
     var body: some View {
-        @Bindable var viewModel = viewModel
-        
         VStack(spacing: 16) {
             if !viewModel.emailSent {
                 Text(Constants.ProfileView.forgetPasswordHeader)
@@ -60,7 +58,6 @@ struct ForgotPasswordForm: View {
             }
         }
         .padding()
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onAppear {
             viewModel.emailSent = false
         }
@@ -79,15 +76,6 @@ struct ForgotPasswordForm: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
-    
-    return ForgotPasswordForm()
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.showAlert = true
     
     return ForgotPasswordForm()
         .environment(viewModel)

--- a/EZ Recipes/EZ Recipes/Views/Login/LoginForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/LoginForm.swift
@@ -29,8 +29,6 @@ struct LoginForm: View {
     @State private var passwordEmpty = true
     
     var body: some View {
-        @Bindable var viewModel = viewModel
-        
         VStack(spacing: 16) {
             HStack {
                 Text(Constants.ProfileView.signInSubHeader)
@@ -88,7 +86,6 @@ struct LoginForm: View {
         }
         .padding()
         .keyboardNavigation(focusedField: $focusedField)
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onChange(of: focusedField) {
             withAnimation {
                 if focusedField == .username {
@@ -121,16 +118,6 @@ struct LoginForm: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
-    
-    return LoginForm()
-        .environment(LoginRouter())
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.showAlert = true
     
     return LoginForm()
         .environment(LoginRouter())

--- a/EZ Recipes/EZ Recipes/Views/Login/LoginSheet.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/LoginSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct LoginSheet: View {
     @Bindable var router = LoginRouter()
+    @Environment(ProfileViewModel.self) private var viewModel
     
     var body: some View {
         NavigationStack(path: $router.path) {
@@ -33,5 +34,9 @@ struct LoginSheet: View {
 }
 
 #Preview {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    
     LoginSheet()
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Login/LoginSheet.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/LoginSheet.swift
@@ -12,6 +12,8 @@ struct LoginSheet: View {
     @Environment(ProfileViewModel.self) private var viewModel
     
     var body: some View {
+        @Bindable var viewModel = viewModel
+        
         NavigationStack(path: $router.path) {
             LoginForm()
                 .navigationTitle(Constants.ProfileView.signInHeader)
@@ -30,13 +32,23 @@ struct LoginSheet: View {
                 }
         }
         .environment(router)
+        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
     }
 }
 
-#Preview {
+#Preview("No Alert") {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     
     LoginSheet()
+        .environment(viewModel)
+}
+
+#Preview("Alert") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.showAlert = true
+    
+    return LoginSheet()
         .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Login/SignUpForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/SignUpForm.swift
@@ -33,8 +33,6 @@ struct SignUpForm: View {
     @State private var passwordsDoNotMatch = false
     
     var body: some View {
-        @Bindable var viewModel = viewModel
-        
         VStack(spacing: 16) {
             HStack {
                 Text(Constants.ProfileView.signUpSubHeader)
@@ -104,7 +102,6 @@ struct SignUpForm: View {
         }
         .padding()
         .keyboardNavigation(focusedField: $focusedField)
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onChange(of: focusedField) {
             withAnimation {
                 if focusedField == .email {
@@ -138,16 +135,6 @@ struct SignUpForm: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
-    
-    return SignUpForm()
-        .environment(LoginRouter())
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.showAlert = true
     
     return SignUpForm()
         .environment(LoginRouter())

--- a/EZ Recipes/EZ Recipes/Views/Login/VerifyEmail.swift
+++ b/EZ Recipes/EZ Recipes/Views/Login/VerifyEmail.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct VerifyEmail: View {
+    @Environment(ProfileViewModel.self) private var viewModel
     @State var email: String
     
     // Throttle the number of times the user can resend the verification email to satisfy API limits
@@ -23,7 +24,10 @@ struct VerifyEmail: View {
             HStack {
                 Text(Constants.ProfileView.emailVerifyRetryText)
                 Button {
-                    enableResend = false
+                    Task {
+                        await viewModel.sendVerificationEmail()
+                        enableResend = false
+                    }
                 } label: {
                     Text(Constants.ProfileView.emailVerifyRetryLink)
                 }
@@ -36,7 +40,9 @@ struct VerifyEmail: View {
             HStack {
                 Spacer()
                 Button {
-                    print("Logout")
+                    Task {
+                        await viewModel.logout()
+                    }
                 } label: {
                     Text(Constants.ProfileView.logout)
                 }
@@ -59,5 +65,9 @@ struct VerifyEmail: View {
 }
 
 #Preview {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    
     VerifyEmail(email: Constants.Mocks.chef.email)
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
@@ -1,0 +1,18 @@
+//
+//  DeleteAccountForm.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 3/30/25.
+//
+
+import SwiftUI
+
+struct DeleteAccountForm: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    DeleteAccountForm()
+}

--- a/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
@@ -8,11 +8,84 @@
 import SwiftUI
 
 struct DeleteAccountForm: View {
+    @Environment(ProfileViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var username = ""
+    @State private var usernameMatches = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        @Bindable var viewModel = viewModel
+        
+        VStack(spacing: 16) {
+            Text(Constants.ProfileView.deleteAccountHeader)
+                .font(.title2)
+            Text(Constants.ProfileView.deleteAccountSubHeader)
+                .font(.title3)
+            
+            TextField(Constants.ProfileView.usernameField, text: $username)
+                .textContentType(.username)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: username) {
+                    withAnimation {
+                        usernameMatches = username == viewModel.chef?.email
+                    }
+                }
+            
+            HStack {
+                Spacer()
+                ProgressView()
+                    .opacity(viewModel.isLoading ? 1 : 0)
+                Button {
+                    Task {
+                        await viewModel.deleteAccount()
+                    }
+                } label: {
+                    Text(Constants.ProfileView.deleteAccount)
+                }
+                .font(.title3)
+                .tint(.red)
+                .disabled(!usernameMatches || viewModel.isLoading)
+            }
+        }
+        .padding()
+        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
+        .onChange(of: viewModel.authState) {
+            if viewModel.authState == .unauthenticated {
+                dismiss()
+            }
+        }
     }
 }
 
-#Preview {
-    DeleteAccountForm()
+#Preview("No Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
+    
+    return DeleteAccountForm()
+        .environment(viewModel)
+}
+
+#Preview("Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
+    viewModel.isLoading = true
+    
+    return DeleteAccountForm()
+        .environment(viewModel)
+}
+
+#Preview("Alert") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
+    viewModel.showAlert = true
+    
+    return DeleteAccountForm()
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/DeleteAccountForm.swift
@@ -15,8 +15,6 @@ struct DeleteAccountForm: View {
     @State private var usernameMatches = false
     
     var body: some View {
-        @Bindable var viewModel = viewModel
-        
         VStack(spacing: 16) {
             Text(Constants.ProfileView.deleteAccountHeader)
                 .font(.title2)
@@ -52,7 +50,6 @@ struct DeleteAccountForm: View {
             }
         }
         .padding()
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onChange(of: viewModel.authState) {
             if viewModel.authState == .unauthenticated {
                 dismiss()
@@ -75,16 +72,6 @@ struct DeleteAccountForm: View {
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.chef = mockRepo.mockChef
     viewModel.isLoading = true
-    
-    return DeleteAccountForm()
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.chef = mockRepo.mockChef
-    viewModel.showAlert = true
     
     return DeleteAccountForm()
         .environment(viewModel)

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
@@ -93,14 +93,16 @@ struct ProfileLoggedIn: View {
 #Preview("No Loading") {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
     
-    ProfileLoggedIn(chef: mockRepo.mockChef)
+    return ProfileLoggedIn(chef: mockRepo.mockChef)
         .environment(viewModel)
 }
 
 #Preview("Loading") {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
     viewModel.isLoading = true
     
     return ProfileLoggedIn(chef: mockRepo.mockChef)

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
@@ -13,11 +13,13 @@ struct ProfileLoggedIn: View {
     }
     
     var chef: Chef
-    @Bindable var viewModel: ProfileViewModel
+    @Environment(ProfileViewModel.self) private var viewModel
     
     @State private var formToShow: ProfileForm? = nil
     
     var body: some View {
+        @Bindable var viewModel = viewModel
+        
         VStack {
             Text(Constants.ProfileView.profileHeader(chef.email))
                 .font(.title)
@@ -47,7 +49,6 @@ struct ProfileLoggedIn: View {
                     }
                 }
                 .disabled(viewModel.isLoading)
-                .clipShape(Capsule())
                 Button {
                     formToShow = .updateEmail
                 } label: {
@@ -69,11 +70,7 @@ struct ProfileLoggedIn: View {
                 }
             }
         }
-        .alert(Constants.errorTitle, isPresented: $viewModel.showAlert) {
-            Button(Constants.okButton, role: .cancel) {}
-        } message: {
-            Text(viewModel.recipeError?.error ?? Constants.unknownError)
-        }
+        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .sheet(isPresented: .constant(formToShow != nil), onDismiss: {
             formToShow = nil
         }) {
@@ -95,7 +92,8 @@ struct ProfileLoggedIn: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     
-    ProfileLoggedIn(chef: mockRepo.mockChef, viewModel: viewModel)
+    ProfileLoggedIn(chef: mockRepo.mockChef)
+        .environment(viewModel)
 }
 
 #Preview("Loading") {
@@ -103,5 +101,6 @@ struct ProfileLoggedIn: View {
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
     
-    return ProfileLoggedIn(chef: mockRepo.mockChef, viewModel: viewModel)
+    return ProfileLoggedIn(chef: mockRepo.mockChef)
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
@@ -108,3 +108,13 @@ struct ProfileLoggedIn: View {
     return ProfileLoggedIn(chef: mockRepo.mockChef)
         .environment(viewModel)
 }
+
+#Preview("Alert") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.chef = mockRepo.mockChef
+    viewModel.showAlert = true
+    
+    return ProfileLoggedIn(chef: mockRepo.mockChef)
+        .environment(viewModel)
+}

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedIn.swift
@@ -23,6 +23,7 @@ struct ProfileLoggedIn: View {
         VStack {
             Text(Constants.ProfileView.profileHeader(chef.email))
                 .font(.title)
+                .padding(.horizontal)
             
             HStack {
                 Text(Constants.ProfileView.favorites(chef.favoriteRecipes.count))
@@ -31,7 +32,8 @@ struct ProfileLoggedIn: View {
                 Divider()
                 Text(Constants.RecipeView.totalRatings(chef.ratings.count))
             }
-            .fixedSize() // prevent the dividers from taking up the full height
+            .padding(.horizontal)
+            .fixedSize(horizontal: false, vertical: true) // prevent the dividers from taking up the full height
             
             List {
                 Button {

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct ProfileLoggedOut: View {
-    @Bindable var viewModel: ProfileViewModel
+    @Environment(ProfileViewModel.self) private var viewModel
     
     var body: some View {
+        @Bindable var viewModel = viewModel
+        
         VStack {
             Text(Constants.ProfileView.loginMessage)
             
@@ -44,5 +46,6 @@ struct ProfileLoggedOut: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     
-    ProfileLoggedOut(viewModel: viewModel)
+    ProfileLoggedOut()
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
@@ -8,18 +8,18 @@
 import SwiftUI
 
 struct ProfileLoggedOut: View {
-    @State private var showLoginSheet = false
+    @Bindable var viewModel: ProfileViewModel
     
     var body: some View {
         VStack {
             Text(Constants.ProfileView.loginMessage)
             
             Button {
-                showLoginSheet.toggle()
+                viewModel.openLoginSheet = true
             } label: {
                 Text(Constants.ProfileView.login)
             }
-            .sheet(isPresented: $showLoginSheet) {
+            .sheet(isPresented: $viewModel.openLoginSheet) {
                 LoginSheet()
             }
             
@@ -27,9 +27,22 @@ struct ProfileLoggedOut: View {
         }
         .padding()
         .font(.title2)
+        .onChange(of: [viewModel.passwordUpdated, viewModel.accountDeleted]) {
+            // Show messages after actions that force the user to be signed out
+            if viewModel.passwordUpdated {
+                print(Constants.ProfileView.changePasswordSuccess)
+                viewModel.passwordUpdated = false
+            } else if viewModel.accountDeleted {
+                print(Constants.ProfileView.deleteAccountSuccess)
+                viewModel.accountDeleted = false
+            }
+        }
     }
 }
 
 #Preview {
-    ProfileLoggedOut()
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    
+    ProfileLoggedOut(viewModel: viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileLoggedOut.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AlertToast
 
 struct ProfileLoggedOut: View {
     @Environment(ProfileViewModel.self) private var viewModel
@@ -29,23 +30,38 @@ struct ProfileLoggedOut: View {
         }
         .padding()
         .font(.title2)
-        .onChange(of: [viewModel.passwordUpdated, viewModel.accountDeleted]) {
-            // Show messages after actions that force the user to be signed out
-            if viewModel.passwordUpdated {
-                print(Constants.ProfileView.changePasswordSuccess)
-                viewModel.passwordUpdated = false
-            } else if viewModel.accountDeleted {
-                print(Constants.ProfileView.deleteAccountSuccess)
-                viewModel.accountDeleted = false
-            }
+        // Show messages after actions that force the user to be signed out
+        .toast(isPresenting: $viewModel.passwordUpdated) {
+            AlertToast(displayMode: .banner(.pop), type: .regular, title: Constants.ProfileView.changePasswordSuccessHeader, subTitle: Constants.ProfileView.changePasswordSuccessSubHeader)
+        }
+        .toast(isPresenting: $viewModel.accountDeleted) {
+            AlertToast(displayMode: .banner(.pop), type: .regular, title: Constants.ProfileView.deleteAccountSuccess)
         }
     }
 }
 
-#Preview {
+#Preview("Regular") {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     
     ProfileLoggedOut()
+        .environment(viewModel)
+}
+
+#Preview("Password Updated") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.passwordUpdated = true
+    
+    return ProfileLoggedOut()
+        .environment(viewModel)
+}
+
+#Preview("Account Deleted") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.accountDeleted = true
+    
+    return ProfileLoggedOut()
         .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/ProfileView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/ProfileView.swift
@@ -15,9 +15,9 @@ struct ProfileView: View {
         NavigationStack {
             Group {
                 if viewModel.authState == .authenticated, let chef = viewModel.chef {
-                    ProfileLoggedIn(chef: chef, viewModel: viewModel)
+                    ProfileLoggedIn(chef: chef)
                 } else if viewModel.authState == .unauthenticated {
-                    ProfileLoggedOut(viewModel: viewModel)
+                    ProfileLoggedOut()
                 } else {
                     VStack {
                         ProgressView()
@@ -27,6 +27,7 @@ struct ProfileView: View {
             }
             .navigationTitle(Constants.ProfileView.profileTitle)
         }
+        .environment(viewModel)
         .task {
             // Check if the user is authenticated every time the profile tab is launched or deep linked
             if !isPreview {

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
@@ -8,11 +8,82 @@
 import SwiftUI
 
 struct UpdateEmailForm: View {
+    @Environment(ProfileViewModel.self) private var viewModel
+    @State private var email = ""
+    
+    @State private var emailTouched = false
+    
+    @State private var emailEmpty = true
+    @State private var emailInvalid = true
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        @Bindable var viewModel = viewModel
+        VStack(spacing: 16) {
+            if !viewModel.emailSent {
+                TextField(Constants.ProfileView.changeEmailField, text: $email)
+                    .textContentType(.emailAddress)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: email) {
+                        withAnimation {
+                            emailTouched = true
+                            emailEmpty = email.isEmpty
+                            emailInvalid = email.wholeMatch(of: Constants.emailRegex) == nil
+                        }
+                    }
+                FormError(on: emailTouched && emailEmpty, message: Constants.ProfileView.fieldRequired("Email"))
+                FormError(on: emailTouched && emailInvalid, message: Constants.ProfileView.emailInvalid)
+                
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .opacity(viewModel.isLoading ? 1 : 0)
+                    Button {
+                        Task {
+                            await viewModel.updateEmail(newEmail: email)
+                        }
+                    } label: {
+                        Text(Constants.ProfileView.submitButton)
+                    }
+                    .font(.title3)
+                    .disabled(emailEmpty || emailInvalid || viewModel.isLoading)
+                }
+            } else {
+                Text(Constants.ProfileView.changeEmailConfirm(email))
+            }
+        }
+        .padding()
+        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
+        .onAppear {
+            viewModel.emailSent = false
+        }
     }
 }
 
-#Preview {
+#Preview("No Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    
     UpdateEmailForm()
+        .environment(viewModel)
+}
+
+#Preview("Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.isLoading = true
+    
+    return UpdateEmailForm()
+        .environment(viewModel)
+}
+
+#Preview("Alert") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.showAlert = true
+    
+    return UpdateEmailForm()
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateEmailForm.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 3/30/25.
+//
+
+import SwiftUI
+
+struct UpdateEmailForm: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    UpdateEmailForm()
+}

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
@@ -18,6 +18,9 @@ struct UpdateEmailForm: View {
     
     var body: some View {
         VStack(spacing: 16) {
+            Text(Constants.ProfileView.changeEmail)
+                .font(.title2)
+            
             if !viewModel.emailSent {
                 TextField(Constants.ProfileView.changeEmailField, text: $email)
                     .textContentType(.emailAddress)

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdateEmailForm.swift
@@ -17,7 +17,6 @@ struct UpdateEmailForm: View {
     @State private var emailInvalid = true
     
     var body: some View {
-        @Bindable var viewModel = viewModel
         VStack(spacing: 16) {
             if !viewModel.emailSent {
                 TextField(Constants.ProfileView.changeEmailField, text: $email)
@@ -55,7 +54,6 @@ struct UpdateEmailForm: View {
             }
         }
         .padding()
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onAppear {
             viewModel.emailSent = false
         }
@@ -74,15 +72,6 @@ struct UpdateEmailForm: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
-    
-    return UpdateEmailForm()
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.showAlert = true
     
     return UpdateEmailForm()
         .environment(viewModel)

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
@@ -28,8 +28,6 @@ struct UpdatePasswordForm: View {
     @State private var passwordsDoNotMatch = false
     
     var body: some View {
-        @Bindable var viewModel = viewModel
-        
         VStack(spacing: 16) {
             SecureTextField(label: Constants.ProfileView.changePasswordField, text: $password, isNewPassword: true)
                 .focused($focusedField, equals: .password)
@@ -73,7 +71,6 @@ struct UpdatePasswordForm: View {
         }
         .padding()
         .keyboardNavigation(focusedField: $focusedField)
-        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
         .onChange(of: focusedField) {
             withAnimation {
                 if focusedField == .password {
@@ -103,15 +100,6 @@ struct UpdatePasswordForm: View {
     let mockRepo = NetworkManagerMock.shared
     let viewModel = ProfileViewModel(repository: mockRepo)
     viewModel.isLoading = true
-    
-    return UpdatePasswordForm()
-        .environment(viewModel)
-}
-
-#Preview("Alert") {
-    let mockRepo = NetworkManagerMock.shared
-    let viewModel = ProfileViewModel(repository: mockRepo)
-    viewModel.showAlert = true
     
     return UpdatePasswordForm()
         .environment(viewModel)

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
@@ -8,11 +8,111 @@
 import SwiftUI
 
 struct UpdatePasswordForm: View {
+    private enum Field: CaseIterable {
+        case password
+        case passwordConfirm
+    }
+    
+    @Environment(ProfileViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+    
+    @State private var password = ""
+    @State private var passwordConfirm = ""
+    
+    @State private var passwordTouched = false
+    @State private var passwordConfirmTouched = false
+    
+    @State private var passwordEmpty = true
+    @State private var passwordTooShort = true
+    @State private var passwordsDoNotMatch = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        @Bindable var viewModel = viewModel
+        
+        VStack(spacing: 16) {
+            SecureTextField(label: Constants.ProfileView.changePasswordField, text: $password, isNewPassword: true)
+                .focused($focusedField, equals: .password)
+                .onChange(of: password) {
+                    withAnimation {
+                        passwordEmpty = password.isEmpty
+                        passwordTooShort = password.count < Constants.passwordMinLength
+                    }
+                }
+                .onChange(of: [password, passwordConfirm]) {
+                    withAnimation {
+                        passwordsDoNotMatch = password != passwordConfirm
+                    }
+                }
+            FormError(on: passwordTouched && passwordEmpty, message: Constants.ProfileView.fieldRequired("Password"))
+            FormError(on: passwordTouched && passwordTooShort, message: Constants.ProfileView.passwordMinLengthError)
+            
+            SecureTextField(label: Constants.ProfileView.passwordConfirmField, text: $passwordConfirm, isNewPassword: true)
+                .focused($focusedField, equals: .passwordConfirm)
+            // Supporting text
+            if !passwordsDoNotMatch {
+                Text(Constants.ProfileView.passwordMinLengthInfo)
+                    .font(.subheadline)
+            }
+            FormError(on: passwordConfirmTouched && passwordsDoNotMatch, message: Constants.ProfileView.passwordMatch)
+            
+            HStack {
+                Spacer()
+                ProgressView()
+                    .opacity(viewModel.isLoading ? 1 : 0)
+                Button {
+                    Task {
+                        await viewModel.updatePassword(newPassword: password)
+                    }
+                } label: {
+                    Text(Constants.ProfileView.submitButton)
+                }
+                .font(.title3)
+                .disabled(passwordEmpty || passwordTooShort || passwordsDoNotMatch || viewModel.isLoading)
+            }
+        }
+        .padding()
+        .keyboardNavigation(focusedField: $focusedField)
+        .errorAlert(isPresented: $viewModel.showAlert, message: viewModel.recipeError?.error)
+        .onChange(of: focusedField) {
+            withAnimation {
+                if focusedField == .password {
+                    passwordTouched = true
+                } else if focusedField == .passwordConfirm {
+                    passwordConfirmTouched = true
+                }
+            }
+        }
+        .onChange(of: viewModel.passwordUpdated) {
+            if viewModel.passwordUpdated {
+                dismiss()
+            }
+        }
     }
 }
 
-#Preview {
+#Preview("No Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    
     UpdatePasswordForm()
+        .environment(viewModel)
+}
+
+#Preview("Loading") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.isLoading = true
+    
+    return UpdatePasswordForm()
+        .environment(viewModel)
+}
+
+#Preview("Alert") {
+    let mockRepo = NetworkManagerMock.shared
+    let viewModel = ProfileViewModel(repository: mockRepo)
+    viewModel.showAlert = true
+    
+    return UpdatePasswordForm()
+        .environment(viewModel)
 }

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
@@ -1,0 +1,18 @@
+//
+//  UpdatePasswordForm.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 3/30/25.
+//
+
+import SwiftUI
+
+struct UpdatePasswordForm: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    UpdatePasswordForm()
+}

--- a/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Profile/UpdatePasswordForm.swift
@@ -29,6 +29,9 @@ struct UpdatePasswordForm: View {
     
     var body: some View {
         VStack(spacing: 16) {
+            Text(Constants.ProfileView.changePassword)
+                .font(.title2)
+            
             SecureTextField(label: Constants.ProfileView.changePasswordField, text: $password, isNewPassword: true)
                 .focused($focusedField, equals: .password)
                 .onChange(of: password) {

--- a/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/SubmitButton.swift
@@ -24,11 +24,7 @@ struct SubmitButton: View {
                     }
                 }
                 .disabled(viewModel.isLoading)
-                .alert(Constants.errorTitle, isPresented: $viewModel.recipeFailedToLoad) {
-                    Button(Constants.okButton, role: .cancel) {}
-                } message: {
-                    Text(viewModel.recipeError?.error ?? Constants.unknownError)
-                }
+                .errorAlert(isPresented: $viewModel.recipeFailedToLoad, message: viewModel.recipeError?.error)
                 .padding(.trailing)
                 
                 ProgressView()

--- a/EZ Recipes/EZ Recipes/Views/ViewModifiers/ErrorAlert.swift
+++ b/EZ Recipes/EZ Recipes/Views/ViewModifiers/ErrorAlert.swift
@@ -1,0 +1,33 @@
+//
+//  ErrorAlert.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 3/30/25.
+//
+
+import SwiftUI
+
+private struct ErrorAlert: ViewModifier {
+    var isPresented: Binding<Bool>
+    var message: String?
+    
+    func body(content: Content) -> some View {
+        content
+            .alert(Constants.errorTitle, isPresented: isPresented) {
+                Button(Constants.okButton, role: .cancel) {}
+            } message: {
+                Text(message ?? Constants.unknownError)
+            }
+    }
+}
+
+extension View {
+    /// Show an alert with an error message and an OK button
+    /// - Parameters:
+    ///   - isPresented: a binding to a Bool determining if the alert should be shown
+    ///   - message: the error message to show inside the alert; if `nil` is provided, a default error message is shown
+    /// - Returns: the resulting View
+    func errorAlert(isPresented: Binding<Bool>, message: String?) -> some View {
+        modifier(ErrorAlert(isPresented: isPresented, message: message))
+    }
+}

--- a/EZ Recipes/EZ RecipesTests/Helpers/KeychainManagerTests.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/KeychainManagerTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import EZ_Recipes
 
 @Suite struct KeychainManagerTests {
-    let key: KeychainManager.Key = .token
+    let key: KeychainManager.Key = .mockToken
     let token = "mockJwt"
     
     init() throws {

--- a/EZ Recipes/EZ RecipesTests/Helpers/LoginRouterTests.swift
+++ b/EZ Recipes/EZ RecipesTests/Helpers/LoginRouterTests.swift
@@ -1,0 +1,68 @@
+//
+//  LoginRouterTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 3/30/25.
+//
+
+import Testing
+@testable import EZ_Recipes
+
+@Suite struct LoginRouterTests {
+    private let loginRouter = LoginRouter()
+    
+    @Test func navigateWithEmptyPath() {
+        // Given an empty path
+        loginRouter.path = []
+        
+        // When navigating to a route
+        loginRouter.navigate(to: .signUp)
+        
+        // Then the route is added to the path
+        #expect(loginRouter.path == [.signUp])
+    }
+    
+    @Test func navigateToUniqueRoute() {
+        // Given a path
+        loginRouter.path = [.forgotPassword, .signUp]
+        
+        // When navigating to a new route
+        loginRouter.navigate(to: .verifyEmail(email: Constants.Mocks.chef.email))
+        
+        // Then the route is appended to the path
+        #expect(loginRouter.path == [.forgotPassword, .signUp, .verifyEmail(email: Constants.Mocks.chef.email)])
+    }
+    
+    @Test func navigateToExistingRoute() {
+        // Given a path
+        loginRouter.path = [.forgotPassword, .signUp]
+        
+        // When navigating to an existing route
+        loginRouter.navigate(to: .forgotPassword)
+        
+        // Then the router pops to the existing route
+        #expect(loginRouter.path == [.forgotPassword])
+    }
+    
+    @Test func navigateBack() {
+        // Given a path
+        loginRouter.path = [.signUp]
+        
+        // When navigating back
+        loginRouter.goBack()
+        
+        // Then the last route is removed from the path
+        #expect(loginRouter.path.isEmpty)
+    }
+    
+    @Test func navigateBackWithEmptyPath() {
+        // Given an empty path
+        loginRouter.path = []
+        
+        // When navigating back
+        loginRouter.goBack()
+        
+        // Then nothing happens
+        #expect(loginRouter.path.isEmpty)
+    }
+}

--- a/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
@@ -1,0 +1,395 @@
+//
+//  ProfileViewModelTests.swift
+//  EZ RecipesTests
+//
+//  Created by Abhishek Chaudhuri on 3/29/25.
+//
+
+import Testing
+@testable import EZ_Recipes
+
+private extension ProfileViewModel {
+    convenience init(isSuccess: Bool = true, isEmailVerified: Bool = true) {
+        var mockRepo = NetworkManagerMock.shared
+        mockRepo.isSuccess = isSuccess
+        mockRepo.isEmailVerified = isEmailVerified
+        
+        self.init(repository: mockRepo)
+    }
+}
+
+@MainActor
+@Suite struct ProfileViewModelTests {
+    private let mockRepo = NetworkManagerMock.shared
+    
+    init() {
+        try? KeychainManager.delete(key: .token)
+    }
+    
+    @Test func createAccountSuccess() async throws {
+        // Given the user's credentials
+        let username = "test@example.com"
+        let password = "test1234"
+
+        // When creating an account
+        let viewModel = ProfileViewModel()
+        await viewModel.createAccount(username: username, password: password)
+
+        // Then a new chef should be created
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.chef == Chef(uid: mockRepo.mockLoginResponse.uid, email: username, emailVerified: mockRepo.mockLoginResponse.emailVerified, ratings: [:], recentRecipes: [:], favoriteRecipes: [], token: mockRepo.mockLoginResponse.token))
+
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockLoginResponse.token)
+    }
+
+    @Test func createAccountError() async {
+        // Given the user's credentials
+        let username = "test@example.com"
+        let password = "test1234"
+
+        // When creating an account and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.createAccount(username: username, password: password)
+
+        // Then an error is shown
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func sendVerificationEmailSuccess() async throws {
+        // Given a valid token
+        // When sending a verification email
+        let viewModel = ProfileViewModel()
+        await viewModel.sendVerificationEmail()
+
+        // Then the email should be sent
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockChefEmailResponse.token)
+    }
+
+    @Test func sendVerificationEmailError() async {
+        // Given valid token
+        // When sending a verification email and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.sendVerificationEmail()
+
+        // Then an error is shown
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func sendVerificationEmailNoToken() async {
+        // Given no token
+        // When sending a verification email
+        let viewModel = ProfileViewModel()
+        await viewModel.sendVerificationEmail()
+
+        // Then an error alert isn't shown
+        #expect(viewModel.recipeError == RecipeError(error: Constants.noTokenFound))
+        #expect(!viewModel.showAlert)
+    }
+
+    @Test func resetPasswordSuccess() async {
+        // Given an email
+        let email = "test@example.com"
+
+        // When resetting the password
+        let viewModel = ProfileViewModel()
+        await viewModel.resetPassword(email: email)
+
+        // Then an email should be sent
+        #expect(viewModel.emailSent)
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+    }
+
+    @Test func resetPasswordError() async {
+        // Given an email
+        let email = "test@example.com"
+
+        // When resetting the password and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.resetPassword(email: email)
+
+        // Then an error is shown
+        #expect(!viewModel.emailSent)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func getChefSuccess() async throws {
+        // Given a valid token
+        // When getting the chef's profile
+        let viewModel = ProfileViewModel()
+        await viewModel.getChef()
+
+        // Then the chef is saved and the user is authenticated
+        #expect(viewModel.chef == mockRepo.mockChef)
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.authState == .authenticated)
+        
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockChefEmailResponse.token)
+    }
+
+    @Test func getChefError() async {
+        // Given a valid token
+        // When getting the chef's profile and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.getChef()
+
+        // Then the user is unauthenticated
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+        #expect(viewModel.authState == .unauthenticated)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func getChefNoToken() async {
+        // Given no token
+        // When getting the chef's profile
+        let viewModel = ProfileViewModel()
+        await viewModel.getChef()
+
+        // Then the user is unauthenticated
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.recipeError == RecipeError(error: Constants.noTokenFound))
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.authState == .unauthenticated)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func loginSuccess() async throws {
+        // Given the user's credentials
+        let username = "test@example.com"
+        let password = "test1234"
+
+        // When logging in
+        let viewModel = ProfileViewModel()
+        await viewModel.login(username: username, password: password)
+
+        // Then the user should be authenticated
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.chef == Chef(uid: mockRepo.mockLoginResponse.uid, email: mockRepo.mockChef.email, emailVerified: mockRepo.mockLoginResponse.emailVerified, ratings: mockRepo.mockChef.ratings, recentRecipes: mockRepo.mockChef.recentRecipes, favoriteRecipes: mockRepo.mockChef.favoriteRecipes, token: mockRepo.mockLoginResponse.token))
+        #expect(viewModel.authState == .authenticated)
+        #expect(!viewModel.openLoginSheet)
+
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockLoginResponse.token)
+    }
+
+    @Test func loginEmailNotVerified() async throws {
+        // Given the user hasn't verified their email
+        let username = "test@example.com"
+        let password = "test1234"
+
+        // When logging in
+        let viewModel = ProfileViewModel(isEmailVerified: false)
+        await viewModel.login(username: username, password: password)
+
+        // Then a new chef should be created, but the user shouldn't be authenticated
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.chef == Chef(uid: mockRepo.mockLoginResponse.uid, email: mockRepo.mockChef.email, emailVerified: false, ratings: mockRepo.mockChef.ratings, recentRecipes: mockRepo.mockChef.recentRecipes, favoriteRecipes: mockRepo.mockChef.favoriteRecipes, token: mockRepo.mockLoginResponse.token))
+        #expect(viewModel.authState != .authenticated)
+
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockLoginResponse.token)
+    }
+
+    @Test func loginError() async {
+        // Given the user's credentials
+        let username = "test@example.com"
+        let password = "test1234"
+
+        // When logging in and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.login(username: username, password: password)
+
+        // Then an error is shown
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func logoutSuccess() async {
+        // Given a valid token
+        // When logging out
+        let viewModel = ProfileViewModel()
+        await viewModel.logout()
+
+        // Then the user is unauthenticated
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.authState == .unauthenticated)
+        #expect(!viewModel.openLoginSheet)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func logoutError() async {
+        // Given a valid token
+        // When logging out and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.logout()
+
+        // Then an error is shown
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func logoutNoToken() async {
+        // Given no token
+        // When logging out
+        let viewModel = ProfileViewModel()
+        await viewModel.logout()
+
+        // Then the user is unauthenticated
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.authState == .unauthenticated)
+        #expect(!viewModel.openLoginSheet)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func updateEmailSuccess() async throws {
+        // Given a valid token
+        let newEmail = "mock@example.com"
+
+        // When updating the chef's email
+        let viewModel = ProfileViewModel()
+        await viewModel.updateEmail(newEmail: newEmail)
+
+        // Then an email should be sent
+        #expect(viewModel.emailSent)
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+
+        #expect(try KeychainManager.retrieve(forKey: .token) == mockRepo.mockChefEmailResponse.token)
+    }
+
+    @Test func updateEmailError() async {
+        // Given a valid token
+        let newEmail = "mock@example.com"
+
+        // When updating the chef's email and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.updateEmail(newEmail: newEmail)
+
+        // Then an error is shown
+        #expect(!viewModel.emailSent)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func updateEmailNoToken() async {
+        // Given no token
+        let newEmail = "mock@example.com"
+
+        // When updating the chef's email
+        let viewModel = ProfileViewModel()
+        await viewModel.updateEmail(newEmail: newEmail)
+
+        // Then an error alert isn't shown
+        #expect(!viewModel.emailSent)
+        #expect(viewModel.recipeError == RecipeError(error: Constants.noTokenFound))
+        #expect(!viewModel.showAlert)
+    }
+
+    @Test func updatePasswordSuccess() async {
+        // Given a valid token
+        let newPassword = "mockPassword"
+
+        // When updating the chef's password
+        let viewModel = ProfileViewModel()
+        await viewModel.updatePassword(newPassword: newPassword)
+
+        // Then the password should be updated and the user should be signed out
+        #expect(viewModel.passwordUpdated)
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+        #expect(viewModel.authState == .unauthenticated)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func updatePasswordError() async {
+        // Given a valid token
+        let newPassword = "mockPassword"
+
+        // When updating the chef's password and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.updatePassword(newPassword: newPassword)
+
+        // Then an error is shown
+        #expect(!viewModel.passwordUpdated)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func updatePasswordNoToken() async {
+        // Given no token
+        let newPassword = "mockPassword"
+        
+        // When updating the chef's password
+        let viewModel = ProfileViewModel()
+        await viewModel.updatePassword(newPassword: newPassword)
+
+        // Then an error alert isn't shown
+        #expect(!viewModel.passwordUpdated)
+        #expect(viewModel.recipeError == RecipeError(error: Constants.noTokenFound))
+        #expect(!viewModel.showAlert)
+    }
+
+    @Test func deleteAccountSuccess() async {
+        // Given a valid token
+        // When deleting the chef's account
+        let viewModel = ProfileViewModel()
+        await viewModel.deleteAccount()
+
+        // Then the chef should be deleted and unauthenticated
+        #expect(viewModel.chef == nil)
+        #expect(viewModel.authState == .unauthenticated)
+        #expect(viewModel.accountDeleted)
+        #expect(viewModel.recipeError == nil)
+        #expect(!viewModel.showAlert)
+
+        #expect(throws: (any Error).self) {
+            try KeychainManager.retrieve(forKey: .token)
+        }
+    }
+
+    @Test func deleteAccountError() async {
+        // Given a valid token
+        // When deleting the chef's account and an error occurs
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.deleteAccount()
+
+        // Then an error is shown
+        #expect(!viewModel.accountDeleted)
+        #expect(viewModel.recipeError == Constants.Mocks.tokenError)
+    }
+
+    @Test func deleteAccountNoToken() async {
+        // Given no token
+        // When deleting the chef's account
+        let viewModel = ProfileViewModel()
+        await viewModel.deleteAccount()
+
+        // Then an error alert isn't shown
+        #expect(!viewModel.accountDeleted)
+        #expect(viewModel.recipeError == RecipeError(error: Constants.noTokenFound))
+        #expect(!viewModel.showAlert)
+    }
+}

--- a/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
@@ -23,6 +23,11 @@ private extension ProfileViewModel {
     private let mockRepo = NetworkManagerMock.shared
     
     init() {
+        // By default, add a token to the Keychain
+        try? KeychainManager.save(entry: mockRepo.mockChef.token, forKey: .token)
+    }
+    
+    private func clearToken() {
         try? KeychainManager.delete(key: .token)
     }
     
@@ -82,6 +87,8 @@ private extension ProfileViewModel {
 
     @Test func sendVerificationEmailNoToken() async {
         // Given no token
+        clearToken()
+        
         // When sending a verification email
         let viewModel = ProfileViewModel()
         await viewModel.sendVerificationEmail()
@@ -151,6 +158,8 @@ private extension ProfileViewModel {
 
     @Test func getChefNoToken() async {
         // Given no token
+        clearToken()
+        
         // When getting the chef's profile
         let viewModel = ProfileViewModel()
         await viewModel.getChef()
@@ -247,6 +256,8 @@ private extension ProfileViewModel {
 
     @Test func logoutNoToken() async {
         // Given no token
+        clearToken()
+        
         // When logging out
         let viewModel = ProfileViewModel()
         await viewModel.logout()
@@ -294,6 +305,7 @@ private extension ProfileViewModel {
 
     @Test func updateEmailNoToken() async {
         // Given no token
+        clearToken()
         let newEmail = "mock@example.com"
 
         // When updating the chef's email
@@ -340,6 +352,7 @@ private extension ProfileViewModel {
 
     @Test func updatePasswordNoToken() async {
         // Given no token
+        clearToken()
         let newPassword = "mockPassword"
         
         // When updating the chef's password
@@ -383,6 +396,8 @@ private extension ProfileViewModel {
 
     @Test func deleteAccountNoToken() async {
         // Given no token
+        clearToken()
+        
         // When deleting the chef's account
         let viewModel = ProfileViewModel()
         await viewModel.deleteAccount()

--- a/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
@@ -19,7 +19,7 @@ private extension ProfileViewModel {
 }
 
 @MainActor
-@Suite struct ProfileViewModelTests {
+@Suite(.serialized) struct ProfileViewModelTests {
     private let mockRepo = NetworkManagerMock.shared
     
     init() {


### PR DESCRIPTION
_The iOS implementation of https://github.com/Abhiek187/ez-recipes-web/issues/6, https://github.com/Abhiek187/ez-recipes-web/issues/7, & https://github.com/Abhiek187/ez-recipes-web/issues/312_

I created the `ProfileViewModel` and integrated all the login and profile update APIs, so we can now test the login experience end-to-end.

Now that I can test POST requests, I realized that I need to pass a JSON encoder to these Alamofire sessions so the appropriate content type is used instead of the default URL-encoded form parameters. Also, I needed to fix the regex check for passwords in the body. Now the logs are redacted properly:

> [AF Request] Method: POST | URL: https://ez-recipes-server.onrender.com/api/chefs/login | Headers: ["Content-Type": "application/json"] | Data: {"email":"abhishek.chaudhuri@rutgers.edu","password":"██"}
> [AF Request] Method: GET | URL: https://ez-recipes-server.onrender.com/api/chefs | Headers: ["Authorization": "██"]

Speaking of Alamofire, I optimized how we're parsing the response so we only await once. To support multiple data types, I serialized the response as Data and then used the JSON decoder to try converting the data into different types. If the response isn't JSON, such as if we hit our quota, we show the full error response. If all else fails, we show the error Alamofire returns.

<img src="https://github.com/user-attachments/assets/3911285f-3c94-4146-be97-0d21ba194edf" alt="too-many-requests" width="300">

Since this is the first time I can truly test the Keychain in action, I learned something new. When I add the `.userPresence` flag in `SecAccessControlCreateWithFlags`, the behavior differs between the simulator and real device. The simulator doesn't prompt for biometrics or a passcode since the Keychain uses the Secure Enclave to secure the data. Even though my Mac technically has the hardware to support the enclave (since it has an M chip), it doesn't carry over to the simulator. As a result, this flag does nothing, even if I enable the Face ID/Touch ID feature. On a real device, it initially only prompted me for the passcode. I had to add a Face ID usage description to show the biometric prompt. While showing my face is simple, it gets obnoxious since the prompt always appears every time the token is retrieved from the Keychain. (The prompts don't appear when adding or removing items.) So, I decided to comment out the code and only enforce unlocked devices with passcodes, like how the Android app is configured.

Here are all the flows I could test without entitled access to universal links or autofill:

## Sign Up

https://github.com/user-attachments/assets/675a3c55-4225-4f2d-80ed-e62de40d4702

> [!NOTE]
>
> On a real device, I can tap the email to open the default mail app to quickly view the verification email.

## Email Taken

<img src="https://github.com/user-attachments/assets/ddbd4a8f-11b0-4ac6-b4fb-38a21aadd7b7" alt="email-taken" width="300">

## Forgot Password

https://github.com/user-attachments/assets/402f4a16-2903-40a5-b87e-9256a49fcfb0

## Verify Email

https://github.com/user-attachments/assets/798265b2-da7b-40bb-a6c4-a2183b3b1a16

## Too Many Emails

<img src="https://github.com/user-attachments/assets/c1af39d4-7c36-462b-8446-77ad0d377894" alt="too-many-emails" width="300">

## Change Email

https://github.com/user-attachments/assets/6f0b118c-6dae-48ed-81dc-de66a9372787

## Change Password & Delete Account

With custom toast messages for confirmation:

https://github.com/user-attachments/assets/371fc8de-6dfc-4a39-8b8e-b00285f3a453