### PR TITLE
Home Accordions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-15') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
       - if: matrix.language == 'swift'
         run: |
           echo "Run, Build Application using script"
-          set -o pipefail && env NSUnbufferedIO=YES /Applications/Xcode_16.1.app/Contents/Developer/usr/bin/xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" -disableAutomaticPackageResolution CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild build -project "EZ Recipes/EZ Recipes.xcodeproj" -scheme "EZ Recipes" -disableAutomaticPackageResolution CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -37,6 +37,7 @@ struct Constants {
     ].map {
         String(localized: $0)
     }
+    static let noResults = String(localized: "No recipes found")
     
     // APIs
     static let serverBaseUrl = "https://ez-recipes-server.onrender.com"
@@ -258,7 +259,6 @@ struct Constants {
         static let typeLabel = String(localized: "Meal Type")
         static let cultureLabel = String(localized: "Cuisine")
         static let applyButton = String(localized: "Apply")
-        static let noResults = String(localized: "No recipes found")
         
         // Results
         static let resultsTitle = String(localized: "Results")

--- a/EZ Recipes/EZ Recipes/Helpers/Constants.swift
+++ b/EZ Recipes/EZ Recipes/Helpers/Constants.swift
@@ -15,6 +15,7 @@ struct Constants {
     
     // Common strings
     static let appName = "EZ Recipes"
+    // Using localized strings for automatic translation support
     static let errorTitle = String(localized: "Error")
     static let unknownError = String(localized: "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-ios/issues")
     static let noTokenFound = String(localized: "No token found")
@@ -128,7 +129,6 @@ struct Constants {
     }
     
     struct HomeView {
-        // Using localized strings for automatic translation support
         static let homeTitle = String(localized: "Home")
         static let findRecipeButton = String(localized: "Find Me a Recipe!")
         static let maxRecentRecipes = 10
@@ -136,8 +136,6 @@ struct Constants {
         static let profileFavorites = String(localized: "💖 Favorites")
         static let profileRecentlyViewed = String(localized: "⌚ Recently Viewed")
         static let profileRatings = String(localized: "⭐ Ratings")
-        static let accordionExpand = String(localized: "Expand")
-        static let accordionCollapse = String(localized: "Collapse")
         static let signInForRecipes = String(localized: "Sign in to view your saved recipes")
         
         // Secondary view

--- a/EZ Recipes/EZ Recipes/Localizable.xcstrings
+++ b/EZ Recipes/EZ Recipes/Localizable.xcstrings
@@ -194,9 +194,6 @@
     "Chopping onions... 😭" : {
 
     },
-    "Collapse" : {
-
-    },
     "Confirm Password" : {
 
     },
@@ -252,9 +249,6 @@
 
     },
     "Error: Passwords do not match" : {
-
-    },
-    "Expand" : {
 
     },
     "Fat" : {

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -308,7 +308,8 @@ import Alamofire
         
         // Fetch all recipes in parallel
         await withTaskGroup { group in
-            for (index, recipeId) in recipeIds.enumerated() {
+            // zip is preferred over enumerated for guaranteed 0-based indexing: https://stackoverflow.com/a/63145650
+            for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
                     let result = await self.repository.getRecipe(byId: recipeId)
                     return (result, index, recipeId)
@@ -341,7 +342,7 @@ import Alamofire
         recentRecipes = recipeIds.map { _ in nil }
         
         await withTaskGroup { group in
-            for (index, recipeId) in recipeIds.enumerated() {
+            for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
                     let result = await self.repository.getRecipe(byId: recipeId)
                     return (result, index, recipeId)
@@ -368,7 +369,7 @@ import Alamofire
         ratedRecipes = recipeIds.map { _ in nil }
         
         await withTaskGroup { group in
-            for (index, recipeId) in recipeIds.enumerated() {
+            for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
                     let result = await self.repository.getRecipe(byId: recipeId)
                     return (result, index, recipeId)

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -300,6 +300,8 @@ import Alamofire
         }
     }
     
+    private typealias TaskGroupResult = (Result<Recipe, RecipeError>, Range<Array<Int>.Index>.Element, Int)
+    
     func getAllFavoriteRecipes() async {
         guard let chef else { return }
         
@@ -307,7 +309,7 @@ import Alamofire
         favoriteRecipes = recipeIds.map { _ in nil } // nil == loading
         
         // Fetch all recipes in parallel
-        await withTaskGroup { group in
+        await withTaskGroup(of: TaskGroupResult.self) { group in
             // zip is preferred over enumerated for guaranteed 0-based indexing: https://stackoverflow.com/a/63145650
             for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
@@ -341,7 +343,7 @@ import Alamofire
             .compactMap { $0.0 }
         recentRecipes = recipeIds.map { _ in nil }
         
-        await withTaskGroup { group in
+        await withTaskGroup(of: TaskGroupResult.self) { group in
             for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
                     let result = await self.repository.getRecipe(byId: recipeId)
@@ -368,7 +370,7 @@ import Alamofire
         let recipeIds = chef.ratings.compactMap { (id, _) in Int(id) }
         ratedRecipes = recipeIds.map { _ in nil }
         
-        await withTaskGroup { group in
+        await withTaskGroup(of: TaskGroupResult.self) { group in
             for (index, recipeId) in zip(recipeIds.indices, recipeIds) {
                 group.addTask {
                     let result = await self.repository.getRecipe(byId: recipeId)

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -19,6 +19,10 @@ import Alamofire
     var passwordUpdated = false
     var accountDeleted = false
     
+    var favoriteRecipes: [Recipe?] = []
+    var recentRecipes: [Recipe?] = []
+    var ratedRecipes: [Recipe?] = []
+    
     private(set) var recipeError: RecipeError?
     var showAlert = false
     
@@ -294,6 +298,94 @@ import Alamofire
             self.recipeError = recipeError
             showAlert = token != nil
         }
+    }
+    
+    func getAllFavoriteRecipes() async {
+        guard let chef else { return }
+        
+        let recipeIds = chef.favoriteRecipes.compactMap { Int($0) } // compactMap == non-nil values
+        favoriteRecipes = recipeIds.map { _ in nil } // nil == loading
+        
+        // Fetch all recipes in parallel
+        await withTaskGroup { group in
+            for (index, recipeId) in recipeIds.enumerated() {
+                group.addTask {
+                    let result = await self.repository.getRecipe(byId: recipeId)
+                    return (result, index, recipeId)
+                }
+            }
+            
+            for await (result, index, recipeId) in group {
+                switch result {
+                case .success(let recipeResponse):
+                    // Update the state for this specific recipe
+                    favoriteRecipes[index] = recipeResponse
+                case .failure(let recipeError):
+                    logger.warning("Failed to get recipe \(recipeId) :: error: \(recipeError.error)")
+                }
+            }
+        }
+        
+        // Remove all recipes that failed to load
+        favoriteRecipes.removeAll { $0 == nil }
+    }
+    
+    func getAllRecentRecipes() async {
+        guard let chef else { return }
+        
+        // Sort the recipe IDs by most recent timestamp
+        let recipeIds = chef.recentRecipes
+            .compactMap { (id, timestamp) in (Int(id), timestamp) }
+            .sorted { $0.1 > $1.1 }
+            .compactMap { $0.0 }
+        recentRecipes = recipeIds.map { _ in nil }
+        
+        await withTaskGroup { group in
+            for (index, recipeId) in recipeIds.enumerated() {
+                group.addTask {
+                    let result = await self.repository.getRecipe(byId: recipeId)
+                    return (result, index, recipeId)
+                }
+            }
+            
+            for await (result, index, recipeId) in group {
+                switch result {
+                case .success(let recipeResponse):
+                    recentRecipes[index] = recipeResponse
+                case .failure(let recipeError):
+                    logger.warning("Failed to get recipe \(recipeId) :: error: \(recipeError.error)")
+                }
+            }
+        }
+        
+        recentRecipes.removeAll { $0 == nil }
+    }
+    
+    func getAllRatedRecipes() async {
+        guard let chef else { return }
+        
+        let recipeIds = chef.ratings.compactMap { (id, _) in Int(id) }
+        ratedRecipes = recipeIds.map { _ in nil }
+        
+        await withTaskGroup { group in
+            for (index, recipeId) in recipeIds.enumerated() {
+                group.addTask {
+                    let result = await self.repository.getRecipe(byId: recipeId)
+                    return (result, index, recipeId)
+                }
+            }
+            
+            for await (result, index, recipeId) in group {
+                switch result {
+                case .success(let recipeResponse):
+                    ratedRecipes[index] = recipeResponse
+                case .failure(let recipeError):
+                    logger.warning("Failed to get recipe \(recipeId) :: error: \(recipeError.error)")
+                }
+            }
+        }
+        
+        ratedRecipes.removeAll { $0 == nil }
     }
     
     func updateViews(forRecipe recipe: Recipe) async {

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeAccordions.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeAccordions.swift
@@ -1,0 +1,112 @@
+//
+//  HomeAccordions.swift
+//  EZ Recipes
+//
+//  Created by Abhishek Chaudhuri on 4/19/25.
+//
+
+import SwiftUI
+
+struct HomeAccordions: View {
+    var homeViewModel: HomeViewModel
+    var profileViewModel: ProfileViewModel
+    
+    private struct ToggleStates {
+        var expandFavorites = false
+        var expandRecents = false
+        var expandRatings = false
+    }
+    @State private var toggleStates = ToggleStates()
+    
+    private func recipeCard(_ recipe: Recipe) -> some View {
+        RecipeCard(recipe: recipe, profileViewModel: profileViewModel)
+            .frame(width: 350)
+            .simultaneousGesture(TapGesture().onEnded {
+                // Show the recipe cards animating to the right position after tapping them
+                withAnimation {
+                    homeViewModel.setRecipe(recipe)
+                }
+            })
+    }
+    
+    private func recipeCardLoader() -> some View {
+        RecipeCard(recipe: Constants.Mocks.blueberryYogurt, profileViewModel: profileViewModel)
+            .frame(width: 350)
+            .redacted(reason: .placeholder)
+            .disabled(true)
+    }
+    
+    private func loadRecipeCards(_ recipes: [Recipe?], showWhenOffline: Bool = false) -> some View {
+        let isLoggedIn = profileViewModel.authState == .authenticated
+        let isFetchingChef = profileViewModel.authState == .loading
+        
+        return Group {
+            if !isLoggedIn {
+                if showWhenOffline {
+                    // Show what's stored on the device while the chef isn't signed in
+                    if homeViewModel.recentRecipes.isEmpty {
+                        Text(Constants.noResults)
+                    } else {
+                        ScrollView(.horizontal) {
+                            HStack(spacing: 16) {
+                                ForEach(homeViewModel.recentRecipes, id: \.id) { recentRecipe in
+                                    if let recipe: Recipe = recentRecipe.recipe.decode() {
+                                        recipeCard(recipe)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if isFetchingChef {
+                    // Show the recipe cards loading while waiting for both the auth state & recipes
+                    recipeCardLoader()
+                } else {
+                    // Encourage the user to sign in to see these recipes
+                    Text(Constants.HomeView.signInForRecipes)
+                }
+            } else if recipes.isEmpty {
+                Text(Constants.noResults)
+            } else {
+                ScrollView(.horizontal) {
+                    HStack(spacing: 16) {
+                        // Can't use ForEach directly if the element type is optional
+                        ForEach(Array(zip(recipes.indices, recipes)), id: \.0) { _, recipe in
+                            if let recipe {
+                                recipeCard(recipe)
+                            } else {
+                                recipeCardLoader()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            DisclosureGroup(Constants.HomeView.profileFavorites, isExpanded: $toggleStates.expandFavorites) {
+                loadRecipeCards(profileViewModel.favoriteRecipes)
+            }
+            Divider()
+            DisclosureGroup(Constants.HomeView.profileRecentlyViewed, isExpanded: $toggleStates.expandRecents) {
+                loadRecipeCards(profileViewModel.recentRecipes, showWhenOffline: true)
+            }
+            Divider()
+            DisclosureGroup(Constants.HomeView.profileRatings, isExpanded: $toggleStates.expandRatings) {
+                loadRecipeCards(profileViewModel.ratedRecipes)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    let mockRepo = NetworkManagerMock.shared
+    let swiftData = SwiftDataManager.preview
+    let homeViewModel = HomeViewModel(repository: mockRepo, swiftData: swiftData)
+    
+    let profileViewModel = ProfileViewModel(repository: mockRepo, swiftData: swiftData)
+    
+    return HomeAccordions(homeViewModel: homeViewModel, profileViewModel: profileViewModel)
+}

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     // Subscribe to changes in the ObservableObject and automatically update the UI
     @State var homeViewModel: HomeViewModel
     @State var profileViewModel: ProfileViewModel
+    @State var expandAccordions = false
     @State private var recentRecipes: [RecentRecipe] = []
     
     // Don't show any messages initially if the recipe loads quickly
@@ -19,6 +20,10 @@ struct HomeView: View {
     private let defaultLoadingMessage = " "
     @State private var loadingMessage = " "
     private let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+    
+    @State private var didExpandFavorites = false
+    @State private var didExpandRecent = false
+    @State private var didExpandRates = false
     
     // Up to 3 review prompts can appear every 365 days
     @Environment(\.requestReview) private var requestReview
@@ -28,7 +33,7 @@ struct HomeView: View {
     @AppStorage(UserDefaultsManager.Keys.lastVersionPromptedForReview) var lastVersionPromptedForReview = ""
     private let currentAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     
-    struct ToggleStates {
+    private struct ToggleStates {
         var expandFavorites = false
         var expandRecents = false
         var expandRatings = false
@@ -42,6 +47,73 @@ struct HomeView: View {
                 // Delay for two seconds to avoid interrupting the person using the app
                 try await Task.sleep(for: .seconds(2))
                 requestReview()
+            }
+        }
+    }
+    
+    private func loadRecipeCards(_ recipes: [Recipe?], showWhenOffline: Bool = false) -> some View {
+        let isLoggedIn = profileViewModel.authState == .authenticated
+        let isFetchingChef = profileViewModel.authState == .loading
+        
+        return Group {
+            if !isLoggedIn {
+                if showWhenOffline {
+                    // Show what's stored on the device while the chef isn't signed in
+                    if homeViewModel.recentRecipes.isEmpty {
+                        Text(Constants.noResults)
+                    } else {
+                        ScrollView(.horizontal) {
+                            HStack(spacing: 16) {
+                                ForEach(homeViewModel.recentRecipes, id: \.id) { recentRecipe in
+                                    if let recipe: Recipe = recentRecipe.recipe.decode() {
+                                        RecipeCard(recipe: recipe, profileViewModel: profileViewModel)
+                                            .frame(width: 350)
+                                            .simultaneousGesture(TapGesture().onEnded {
+                                                // Show the recipe cards animating to the right position after tapping them
+                                                withAnimation {
+                                                    homeViewModel.setRecipe(recipe)
+                                                }
+                                            })
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if isFetchingChef {
+                    // Show the recipe cards loading while waiting for both the auth state & recipes
+                    RecipeCard(recipe: Constants.Mocks.blueberryYogurt, profileViewModel: profileViewModel)
+                        .frame(width: 350)
+                        .redacted(reason: .placeholder)
+                        .disabled(true)
+                } else {
+                    // Encourage the user to sign in to see these recipes
+                    Text(Constants.HomeView.signInForRecipes)
+                }
+            } else if recipes.isEmpty {
+                Text(Constants.noResults)
+            } else {
+                ScrollView(.horizontal) {
+                    HStack(spacing: 16) {
+                        // Can't use ForEach directly if the element type is optional
+                        ForEach(Array(zip(recipes.indices, recipes)), id: \.0) { _, recipe in
+                            if let recipe {
+                                RecipeCard(recipe: recipe, profileViewModel: profileViewModel)
+                                    .frame(width: 350)
+                                    .simultaneousGesture(TapGesture().onEnded {
+                                        // Show the recipe cards animating to the right position after tapping them
+                                        withAnimation {
+                                            homeViewModel.setRecipe(recipe)
+                                        }
+                                    })
+                            } else {
+                                RecipeCard(recipe: Constants.Mocks.blueberryYogurt, profileViewModel: profileViewModel)
+                                    .frame(width: 350)
+                                    .redacted(reason: .placeholder)
+                                    .disabled(true)
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -88,33 +160,15 @@ struct HomeView: View {
                     // Saved recipes
                     VStack {
                         DisclosureGroup(Constants.HomeView.profileFavorites, isExpanded: $toggleStates.expandFavorites) {
-                            Text(Constants.HomeView.signInForRecipes)
+                            loadRecipeCards(profileViewModel.favoriteRecipes)
                         }
                         Divider()
                         DisclosureGroup(Constants.HomeView.profileRecentlyViewed, isExpanded: $toggleStates.expandRecents) {
-                            ScrollView(.horizontal) {
-                                HStack {
-                                    ForEach(homeViewModel.recentRecipes, id: \.id) { recentRecipe in
-                                        if let recipe: Recipe = recentRecipe.recipe.decode() {
-                                            RecipeCard(recipe: recipe, profileViewModel: profileViewModel)
-                                                .frame(width: 350)
-                                                .simultaneousGesture(TapGesture().onEnded {
-                                                    // Show the recipe cards animating to the right position after tapping them
-                                                    withAnimation {
-                                                        homeViewModel.setRecipe(recipe)
-                                                    }
-                                                })
-                                        }
-                                    }
-                                }
-                            }
+                            loadRecipeCards(profileViewModel.recentRecipes, showWhenOffline: true)
                         }
                         Divider()
                         DisclosureGroup(Constants.HomeView.profileRatings, isExpanded: $toggleStates.expandRatings) {
-                            RecipeCard(recipe: Constants.Mocks.blueberryYogurt, profileViewModel: profileViewModel)
-                                .frame(width: 350)
-                                .redacted(reason: .placeholder)
-                                .disabled(true)
+                            loadRecipeCards(profileViewModel.ratedRecipes)
                         }
                     }
                     .padding()
@@ -153,32 +207,47 @@ struct HomeView: View {
 }
 
 // Show previews of the HomeView with and without the spinner or an alert box
-#Preview("No Loading") {
-    let repoSuccess = NetworkManagerMock.shared
-    let swiftData = SwiftDataManager.preview
-    let homeViewModel = HomeViewModel(repository: repoSuccess, swiftData: swiftData)
-    let profileViewModel = ProfileViewModel(repository: repoSuccess, swiftData: swiftData)
+// Expand the accordions by default to make it easier to distinguish each preview
+@MainActor
+private func setupPreview(isLoading: Bool = false, showAlert: Bool = false, recentRecipes: [Recipe] = [], authState: AuthState = .unauthenticated, expandAccordions: Bool = true) -> some View {
+    var mockRepo = NetworkManagerMock.shared
+    mockRepo.isSuccess = !showAlert
     
-    return HomeView(homeViewModel: homeViewModel, profileViewModel: profileViewModel)
+    let swiftData = SwiftDataManager.preview
+    let homeViewModel = HomeViewModel(repository: mockRepo, swiftData: swiftData)
+    homeViewModel.isLoading = isLoading
+    homeViewModel.recentRecipes = recentRecipes.map { recipe in
+        RecentRecipe(recipe: recipe)
+    }
+    
+    let profileViewModel = ProfileViewModel(repository: mockRepo, swiftData: swiftData)
+    profileViewModel.isLoading = isLoading
+    profileViewModel.authState = authState
+    profileViewModel.chef = authState == .authenticated ? mockRepo.mockChef : nil
+    
+    return HomeView(homeViewModel: homeViewModel, profileViewModel: profileViewModel, expandAccordions: expandAccordions)
 }
 
-#Preview("Loading") {
-    let repoSuccess = NetworkManagerMock.shared
-    let swiftData = SwiftDataManager.preview
-    let homeViewModel = HomeViewModel(repository: repoSuccess, swiftData: swiftData)
-    homeViewModel.isLoading = true
-    let profileViewModel = ProfileViewModel(repository: repoSuccess, swiftData: swiftData)
-    profileViewModel.isLoading = true
-    
-    return HomeView(homeViewModel: homeViewModel, profileViewModel: profileViewModel)
+#Preview("Offline Recipes") {
+    setupPreview(recentRecipes: [Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken])
+}
+
+#Preview("Authenticated") {
+    setupPreview(authState: .authenticated, expandAccordions: false)
+}
+
+#Preview("Loading (Auth)") {
+    setupPreview(authState: .loading)
+}
+
+#Preview("No Loading") {
+    setupPreview()
+}
+
+#Preview("Loading (Recipe)") {
+    setupPreview(isLoading: true)
 }
 
 #Preview("Alert") {
-    var repoFail = NetworkManagerMock.shared
-    repoFail.isSuccess = false
-    let swiftData = SwiftDataManager.preview
-    let homeViewModel = HomeViewModel(repository: repoFail, swiftData: swiftData)
-    let profileViewModel = ProfileViewModel(repository: repoFail, swiftData: swiftData)
-    
-    return HomeView(homeViewModel: homeViewModel, profileViewModel: profileViewModel)
+    setupPreview(showAlert: true)
 }

--- a/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
+++ b/EZ Recipes/EZ Recipes/Views/Home/HomeView.swift
@@ -21,10 +21,6 @@ struct HomeView: View {
     @State private var loadingMessage = " "
     private let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
     
-    @State private var didExpandFavorites = false
-    @State private var didExpandRecent = false
-    @State private var didExpandRates = false
-    
     // Up to 3 review prompts can appear every 365 days
     @Environment(\.requestReview) private var requestReview
 
@@ -84,7 +80,7 @@ struct HomeView: View {
                         }
                     
                     // Saved recipes
-                    HomeAccordions(homeViewModel: homeViewModel, profileViewModel: profileViewModel)
+                    HomeAccordions(homeViewModel: homeViewModel, profileViewModel: profileViewModel, expandAccordions: expandAccordions)
                 }
             }
             .navigationTitle(Constants.HomeView.homeTitle)
@@ -142,7 +138,7 @@ private func setupPreview(isLoading: Bool = false, showAlert: Bool = false, rece
 }
 
 #Preview("Offline Recipes") {
-    setupPreview(recentRecipes: [Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken])
+    setupPreview(showAlert: true, recentRecipes: [Constants.Mocks.blueberryYogurt, Constants.Mocks.chocolateCupcake, Constants.Mocks.thaiBasilChicken])
 }
 
 #Preview("Authenticated") {

--- a/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
+++ b/EZ Recipes/EZ Recipes/Views/Search/FilterForm.swift
@@ -131,7 +131,7 @@ struct FilterForm: View {
                             noRecipesFound = viewModel.noRecipesFound
                         }
                     }
-                FormError(on: noRecipesFound, message: Constants.SearchView.noResults)
+                FormError(on: noRecipesFound, message: Constants.noResults)
             }
         }
         // Prevent navigation unless the recipes are loaded

--- a/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
@@ -409,6 +409,78 @@ private extension ProfileViewModel {
         #expect(!viewModel.showAlert)
     }
     
+    @Test func getAllFavoriteRecipesSuccess() async {
+        // Given a chef with favorite recipes
+        let viewModel = ProfileViewModel()
+        await viewModel.getChef()
+
+        // When getting all favorite recipes
+        await viewModel.getAllFavoriteRecipes()
+
+        // Then all the recipes are fetched
+        #expect(viewModel.favoriteRecipes.count == mockRepo.mockChef.favoriteRecipes.count)
+    }
+
+    @Test func getAllFavoriteRecipesError() async {
+        // Given a chef with favorite recipes
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.getChef()
+
+        // When getting all favorite recipes and an error occurs
+        await viewModel.getAllFavoriteRecipes()
+
+        // Then no recipes are fetched
+        #expect(viewModel.favoriteRecipes.isEmpty)
+    }
+
+    @Test func getAllRecentRecipesSuccess() async {
+        // Given a chef with recent recipes
+        let viewModel = ProfileViewModel()
+        await viewModel.getChef()
+
+        // When getting all recent recipes
+        await viewModel.getAllRecentRecipes()
+
+        // Then all the recipes are fetched
+        #expect(viewModel.recentRecipes.count == mockRepo.mockChef.recentRecipes.count)
+    }
+
+    @Test func getAllRecentRecipesError() async {
+        // Given a chef with recent recipes
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.getChef()
+
+        // When getting all recent recipes and an error occurs
+        await viewModel.getAllRecentRecipes()
+
+        // Then no recipes are fetched
+        #expect(viewModel.recentRecipes.isEmpty)
+    }
+
+    @Test func getAllRatedRecipesSuccess() async {
+        // Given a chef with rated recipes
+        let viewModel = ProfileViewModel()
+        await viewModel.getChef()
+
+        // When getting all rated recipes
+        await viewModel.getAllRatedRecipes()
+
+        // Then all the recipes are fetched
+        #expect(viewModel.ratedRecipes.count == mockRepo.mockChef.ratings.count)
+    }
+
+    @Test func getAllRatedRecipesError() async {
+        // Given a chef with rated recipes
+        let viewModel = ProfileViewModel(isSuccess: false)
+        await viewModel.getChef()
+
+        // When getting all rated recipes and an error occurs
+        await viewModel.getAllRatedRecipes()
+
+        // Then no recipes are fetched
+        #expect(viewModel.ratedRecipes.isEmpty)
+    }
+    
     @Test func updateRecipeViewsSuccess() async {
         // Given a recipe and a valid token
         let recipe = mockRepo.mockRecipes[0]

--- a/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
+++ b/EZ Recipes/EZ RecipesUITests/EZ_RecipesUITests.swift
@@ -78,6 +78,26 @@ class EZ_RecipesUITests: XCTestCase {
         let homeNavigationBar = app.navigationBars["Home"] // UI tests can't import modules from the app target
         XCTAssert(homeNavigationBar.exists, "Error line \(#line): The home navigation bar couldn't be found")
         
+        // The accordions should be present, but not display any recipes
+        let favoriteAccordion = app.buttons["💖 Favorites"]
+        let recentAccordion = app.buttons["⌚ Recently Viewed"]
+        let ratingAccordion = app.buttons["⭐ Ratings"]
+        let signInMessage = app.staticTexts["Sign in to view your saved recipes"]
+        XCTAssert(favoriteAccordion.exists, "Error line \(#line): The Favorites accordion isn't showing")
+        XCTAssert(recentAccordion.exists, "Error line \(#line): The Recently Viewed accordion isn't showing")
+        XCTAssert(ratingAccordion.exists, "Error line \(#line): The Ratings accordion isn't showing")
+        XCTAssert(!signInMessage.exists, "Error line \(#line): The accordions shouldn't be expanded")
+
+        favoriteAccordion.tap()
+        XCTAssert(signInMessage.exists, "Error line \(#line): The sign in message isn't showing under favorites")
+        favoriteAccordion.tap()
+        recentAccordion.tap()
+        XCTAssert(!signInMessage.exists, "Error line \(#line): The sign in message shouldn't appear under recents")
+        recentAccordion.tap()
+        ratingAccordion.tap()
+        XCTAssert(signInMessage.exists, "Error line \(#line): The sign in message isn't showing under ratings")
+        ratingAccordion.tap()
+        
         // When first launching the app, the find recipe button should be clickable and the ProgressView should be hidden
         let findRecipeButton = app.buttons["Find Me a Recipe!"]
         let progressView = app.activityIndicators.firstMatch

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ Chefs can either find a random recipe or search for one using various filters, i
 
 The app features a glossary to easily look up the meaning of common terms found in recipes. This will better assist newer chefs in learning how to cook, prep certain ingredients, and use certain kitchen tools. Think [How to Stock](https://github.com/Abhiek187/how-to-stock), but for cooking food instead of managing finances.
 
+Creating an account is free and unlocks more exciting features for chefs. This includes favoriting, rating, and syncing recipes across the web and mobile apps. For example, chefs can browse recipes on the web app and open them on the mobile app to cook them in the kitchen.
+
 ## Features
 
 - iOS app created using SwiftUI and MVVM architecture
 - Responsive and accessible mobile design
 - REST APIs to a custom [server](https://github.com/Abhiek187/ez-recipes-server) using Alamofire, which fetches recipe information from [spoonacular](https://spoonacular.com/food-api) and MongoDB
+- Account management using Firebase Authentication
 - Offline data storage using UserDefaults and SwiftData
+- Encryption of sensitive data using the iOS Keychain
 - Universal Links to open recipes from the web app to the mobile app
 - Automated testing and deployment using CI/CD pipelines in GitHub Actions and Fastlane
 - Mermaid to write diagrams as code


### PR DESCRIPTION
https://github.com/user-attachments/assets/9c423133-5aac-45a0-ad8a-02d3ce5604df

https://github.com/user-attachments/assets/72c7d852-ed77-4d2a-af6b-bfae460c2d1a

_The iOS implementation of https://github.com/Abhiek187/ez-recipes-web/issues/311_

The accordions on the home screen have been populated using the same logic as the Android app. All the requests are made in parallel using task groups. I made this part a separate view to prevent the main HomeView from being too bloated. ~As of this writing, I still need to get the view count working no matter the auth state, but I should be able to fix this before merging.~ **(Edit:** The view count does update, but on Android, the accordion closes every time we go back. Whenever we open the accordion, the recipes reload. On iOS, the accordions stay open, so the recipes stay cached. I like this behavior a little bit more, but I'll keep both implementations as-is. If you open another set of accordions—say you open one of your favorites and then open the recently viewed accordion—then you'll see the updated view count.)

The last step will be to thoroughly test on different devices and fix any remaining bugs/polish the UI. Then we can prepare for the next release! I know I've said this a lot, but I'm really tempted to up the request quota to allow for more testing. Just getting this demo prepared used up 55/60 requests allocated per hour. And I'm sure it'll get worse the more recipes I work with. Reaching the spoonacular quota shouldn't be as big of an issue as it was at the start of this project, since we're utilizing MongoDB more and controlling requests on the server side.