### PR TITLE
530 enhance the oauth security

### DIFF
--- a/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
+++ b/EZ Recipes/EZ Recipes.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-Recipes";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abhiek.EZ-Recipes";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/EZ Recipes/EZ Recipes/Models/Profile/OAuthRequest.swift
+++ b/EZ Recipes/EZ Recipes/Models/Profile/OAuthRequest.swift
@@ -7,6 +7,7 @@
 
 struct OAuthRequest: Encodable {
     let code: String
+    let state: String
     let providerId: Provider
     let redirectUrl: String
 }

--- a/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
+++ b/EZ Recipes/EZ Recipes/ViewModels/ProfileViewModel.swift
@@ -243,8 +243,8 @@ import Alamofire
         }
     }
     
-    func loginWithOAuth(code: String, provider: Provider) async {
-        let oAuthRequest = OAuthRequest(code: code, providerId: provider, redirectUrl: Constants.redirectUrl)
+    func loginWithOAuth(code: String, state: String, provider: Provider) async {
+        let oAuthRequest = OAuthRequest(code: code, state: state, providerId: provider, redirectUrl: Constants.redirectUrl)
         let token = getToken()
         
         isLoading = true

--- a/EZ Recipes/EZ Recipes/Views/Helpers/OAuthButton.swift
+++ b/EZ Recipes/EZ Recipes/Views/Helpers/OAuthButton.swift
@@ -31,12 +31,18 @@ struct OAuthButton: View {
                     
                     // Extract the authorization code from the redirect and then exchange it for an ID token
                     let queryItems = URLComponents(string: responseUrl.absoluteString)?.queryItems
-                    let authCode = queryItems?.filter { $0.name == "code" }.first?.value
+                    let authCode = queryItems?.first { $0.name == "code" }?.value
+                    let authState = queryItems?.first { $0.name == "state" }?.value
+                    let expectedState = URLComponents(url: authUrl, resolvingAgainstBaseURL: false)?.queryItems?.first { $0.name == "state" }?.value
+                    
                     guard let authCode else {
                         throw NSError(domain: "No auth code received", code: 0, userInfo: nil)
                     }
+                    guard let authState, authState == expectedState else {
+                        throw NSError(domain: "Invalid auth state received", code: 0, userInfo: nil)
+                    }
                     
-                    await viewModel.loginWithOAuth(code: authCode, provider: provider)
+                    await viewModel.loginWithOAuth(code: authCode, state: authState, provider: provider)
                 } catch {
                     // Don't show an alert if the user closed the auth session
                     if let webError = error as? ASWebAuthenticationSessionError, webError.code == .canceledLogin && webError.userInfo.isEmpty { return }

--- a/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
+++ b/EZ Recipes/EZ RecipesTests/ViewModels/ProfileViewModelTests.swift
@@ -303,13 +303,14 @@ private extension ProfileViewModel {
     }
     
     @Test func loginWithOAuthSuccess() async throws {
-        // Given a code, provider, and token
+        // Given a code, state, provider, and token
         let code = "abc123"
+        let state = "state"
         let provider: Provider = .google
         
         // When linking the provider
         let viewModel = ProfileViewModel()
-        await viewModel.loginWithOAuth(code: code, provider: provider)
+        await viewModel.loginWithOAuth(code: code, state: state, provider: provider)
         
         // Then the chef should be updated
         #expect(viewModel.recipeError == nil)
@@ -323,13 +324,14 @@ private extension ProfileViewModel {
     }
     
     @Test func loginWithOAuthError() async {
-        // Given a code, provider, and token
+        // Given a code, state, provider, and token
         let code = "abc123"
+        let state = "state"
         let provider: Provider = .google
         
         // When linking the provider and an error occurs
         let viewModel = ProfileViewModel(isSuccess: false)
-        await viewModel.loginWithOAuth(code: code, provider: provider)
+        await viewModel.loginWithOAuth(code: code, state: state, provider: provider)
         
         // Then an error is shown
         #expect(viewModel.chef == nil)
@@ -337,14 +339,15 @@ private extension ProfileViewModel {
     }
     
     @Test func loginWithOAuthNoToken() async throws {
-        // Given a code, provider, and no token
+        // Given a code, state, provider, and no token
         let code = "abc123"
+        let state = "state"
         let provider: Provider = .google
         clearToken()
         
         // When logging in with the provider
         let viewModel = ProfileViewModel()
-        await viewModel.loginWithOAuth(code: code, provider: provider)
+        await viewModel.loginWithOAuth(code: code, state: state, provider: provider)
         
         // Then the user should be authenticated
         #expect(viewModel.recipeError == nil)
@@ -358,14 +361,15 @@ private extension ProfileViewModel {
     }
     
     @Test func loginWithOAuthEmailNotVerified() async throws {
-        // Given a code, provider, and no token
+        // Given a code, state, provider, and no token
         let code = "abc123"
+        let state = "state"
         let provider: Provider = .google
         clearToken()
         
         // When logging in with the provider and the email isn't verified
         let viewModel = ProfileViewModel(isEmailVerified: false)
-        await viewModel.loginWithOAuth(code: code, provider: provider)
+        await viewModel.loginWithOAuth(code: code, state: state, provider: provider)
         
         // Then a new chef should be created, but the user shouldn't be authenticated
         #expect(viewModel.recipeError == nil)

--- a/EZ Recipes/fastlane/changelogs/3.2.1.txt
+++ b/EZ Recipes/fastlane/changelogs/3.2.1.txt
@@ -1,0 +1,1 @@
+- Enhance the security of 3rd party login providers


### PR DESCRIPTION
<img width="713" height="171" alt="Screenshot 2026-06-07 at 9 30 42 PM" src="https://github.com/user-attachments/assets/3d60ea29-cb4a-4b13-a112-025e74505f14" />

_The iOS implementation of https://github.com/Abhiek187/ez-recipes-server/issues/530_

Another simple change here. Just need to validate the state sent to us. Here at least, each OAuthButton manages its own callback, so we don't need to worry about which button should respond. The other platforms had global event listeners or ViewModel changes.