### PR TITLE
Use a Grid instead of a LazyVGrid to prevent recipes from hanging

### DIFF
--- a/EZ Recipes/EZ Recipes/Views/Recipe/InstructionsList.swift
+++ b/EZ Recipes/EZ Recipes/Views/Recipe/InstructionsList.swift
@@ -9,11 +9,8 @@ import SwiftUI
 
 struct InstructionsList: View {
     var instructions: [Instruction]
-    
-    // Show step cards side-by-side if there's enough room
-    let columns = [
-        GridItem(.adaptive(minimum: 400), alignment: .top)
-    ]
+    @State private var availableWidth: CGFloat = 0
+    private let cardBreakpoint: CGFloat = 832
     
     var body: some View {
         VStack(spacing: 8) {
@@ -28,11 +25,38 @@ struct InstructionsList: View {
                 }
                 
                 // Steps per instruction
-                LazyVGrid(columns: columns) {
-                    ForEach(instruction.steps, id: \.number) { step in
-                        StepCard(step: step)
+                VStack {
+                    // Using grids is more efficient than using nested lazy grids, but need to handle the grid layout ourselves
+                    let cardsPerRow = availableWidth >= cardBreakpoint ? 2 : 1
+                    let rowCount = (instruction.steps.count + cardsPerRow - 1) / cardsPerRow
+
+                    Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+                        ForEach(0..<rowCount, id: \.self) { row in
+                            GridRow {
+                                let start = row * cardsPerRow
+                                // Stop once we reach the last step
+                                let end = min(start + cardsPerRow, instruction.steps.count)
+                                let stepSlice = instruction.steps[start..<end]
+
+                                ForEach(Array(stepSlice), id: \.number) { step in
+                                    StepCard(step: step)
+                                }
+                            }
+                        }
                     }
                 }
+                // Hidden width checker
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear {
+                                availableWidth = proxy.size.width
+                            }
+                            .onChange(of: proxy.size.width) { _, newWidth in
+                                availableWidth = newWidth
+                            }
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
I noticed a bug where the app would hang as I scrolled down certain recipes. (For example, I was getting consistent results when searching for a cookie recipe.)

This is different from your typical crash. The app never closes, and nothing is logged. This was also a bug I couldn't replicate on the simulator, only on my physical device. I needed another way to troubleshoot the issue. Thanks to an oddly relevant [WWDC video](https://www.youtube.com/watch?v=lWVuP3Vts_0), I learned how to profile the app using Instruments. I used the Time Profiler to record when the app hung. (Side note: I also tried adding the SwiftUI template, but due to the nature of the hang, it would take forever for Instruments to process the data.) The results showed that the main thread was using 100% of the CPU.

<img width="1920" height="1080" alt="instruments-severe-hang" src="https://github.com/user-attachments/assets/be7f47f7-50d6-4a60-a26c-e4ed899a0d3a" />

ChatGPT was able to determine that the stack trace was referring to layout updates from the nested LazyVGrids we had in the IngredientsList & StepCard. In some scenarios, these updates would occur indefinitely, and since UI changes always occur on the main thread, it froze the app in an infinite loop instead of crashing.

The solution was to use something more efficient, like a non-lazy grid. Apple recommends this if the performance doesn't justify using lazy grids. But we would need to compute the number of columns ourselves. For the step cards, I opted to just limit it to 1 or 2 cards per row instead of trying to fit more. That's more consistent with the other platforms anyway. Then we can slice the array to get the appropriate items per row.

I wasn't able to reproduce the hang since then. There may be some stuttering due to the inner LazyVGrid, but I had a harder time figuring out a solution for this without trying to re-implement LazyVGrid ourselves. On that note, I was tempted to replace all the other lazy grids throughout the app (aside from the search results, which do actually justify being lazy given there could be hundreds of results). But this was also tricky since the benefit of LazyVGrids was that it was able to automatically wrap items on subsequent rows and arrange them based on the screen width. This is hard to replicate with just a plain grid. Even changing the GridItem size to fixed or flexible still requires manually computing the number of columns per row.